### PR TITLE
Fix failing web test, update repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Registrator
 
-[![Build Status](https://travis-ci.com/JuliaComputing/Registrator.jl.svg?branch=master)](https://travis-ci.com/JuliaComputing/Registrator.jl)
-[![CodeCov](https://codecov.io/gh/JuliaComputing/Registrator.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaComputing/Registrator.jl)
+[![Build Status](https://travis-ci.com/JuliaRegistries/Registrator.jl.svg?branch=master)](https://travis-ci.com/JuliaRegistries/Registrator.jl)
+[![CodeCov](https://codecov.io/gh/JuliaRegistries/Registrator.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaRegistries/Registrator.jl)
 
 !["amelia robot logo"](graphics/logo.png)
 
@@ -16,7 +16,7 @@ Registrator is a GitHub app that automates creation of registration pull request
 First, install the app on your package(s) as mentioned above.  The procedure for registering a new package is the same as for releasing a new version.
 
 1. Set the [Project.toml](Project.toml) version field in your repository to your new desired `version`.
-2. Comment `@JuliaRegistrator register()` on the commit/branch you want to register (e.g. like [here](https://github.com/JuliaComputing/Registrator.jl/issues/61#issuecomment-483486641) or [here](https://github.com/chakravala/Grassmann.jl/commit/3c3a92610ebc8885619f561fe988b0d985852fce#commitcomment-33233149)).
+2. Comment `@JuliaRegistrator register()` on the commit/branch you want to register (e.g. like [here](https://github.com/JuliaRegistries/Registrator.jl/issues/61#issuecomment-483486641) or [here](https://github.com/chakravala/Grassmann.jl/commit/3c3a92610ebc8885619f561fe988b0d985852fce#commitcomment-33233149)).
 3. If something is incorrect, adjust, and redo step 2.
 4. Finally, either rely on [TagBot](https://github.com/apps/julia-tagbot) to tag and make a github release or alternatively tag the release manually.
 
@@ -41,7 +41,7 @@ Either:
 
 *Note*: Only *collaborators* on the package repository and *public members* on the organization the package is under are allowed to register. If you are not a collaborator, you can request a collaborator trigger registrator in a GitHub issue or a comment on a commit.
 
-If you want to register as a private member you should host your own instance of Registrator, see [docs.md](https://github.com/JuliaComputing/Registrator.jl/blob/master/docs.md)
+If you want to register as a private member you should host your own instance of Registrator, see [docs.md](https://github.com/JuliaRegistries/Registrator.jl/blob/master/docs.md)
 
 ### Note on git tags and GitHub releases
 
@@ -53,6 +53,6 @@ Currently, a registry maintainer will manually merge the pull request made by Re
 
 ## Private packages and registries
 
-Private packages will be ignored by the current running instance of Registrator. Please see [docs.md](https://github.com/JuliaComputing/Registrator.jl/blob/master/docs.md) on how to host your own Registrator for private packages.
+Private packages will be ignored by the current running instance of Registrator. Please see [docs.md](https://github.com/JuliaRegistries/Registrator.jl/blob/master/docs.md) on how to host your own Registrator for private packages.
 
-For more info on running your own instance of Registrator, see the documentation in [docs.md](https://github.com/JuliaComputing/Registrator.jl/blob/master/docs.md)
+For more info on running your own instance of Registrator, see the documentation in [docs.md](https://github.com/JuliaRegistries/Registrator.jl/blob/master/docs.md)

--- a/README.web.md
+++ b/README.web.md
@@ -228,7 +228,7 @@ Install Registrator, apply the environment variables, and run Julia with the ser
 ```sh
 julia -e '
     using Pkg; 
-    Pkg.add("https://github.com/JuliaComputing/Registrator.jl")''
+    Pkg.add("https://github.com/JuliaRegistries/Registrator.jl")''
 source .env
 julia -e '
     using Registrator;

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -ms /bin/bash registrator
 USER registrator
 WORKDIR /home/registrator
 
-RUN julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/JuliaComputing/Registrator.jl\"))"
+RUN julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/JuliaRegistries/Registrator.jl\"))"
 ADD scripts /home/registrator
 
 # Comment out ENTRYPOINT and uncomment the CMD line if you are using Heroku.

--- a/image/scripts/sample.toml
+++ b/image/scripts/sample.toml
@@ -34,7 +34,7 @@ base_branch = "master"
 trigger = "@JuliaRegistrator"   # The comment that should trigger Registrator. Typically
                                 # keep this the same as your GitHub user (with `@` prefixed)
 
-issue_repo = "JuliaComputing/Registrator.jl"
+issue_repo = "JuliaRegistries/Registrator.jl"
 report_issue = false            # If set to true any unhandled error will be reported as
                                 # an issue to the above repository
 

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -17,7 +17,7 @@ const ROUTE_CALLBACK = "/callback"
 const ROUTE_SELECT = "/select"
 const ROUTE_REGISTER = "/register"
 
-const DOCS = "https://github.com/JuliaComputing/Registrator.jl/blob/master/README.web.md#usage-for-package-maintainers"
+const DOCS = "https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.web.md#usage-for-package-maintainers"
 
 const TEMPLATE = """
     <!DOCTYPE html>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,12 @@ using Test
 
 include("server.jl")
 include("regedit.jl")
-include("webui.jl")
+
+# Travis CI gets rate limited easily unless we have access to an API key.
+if get(ENV, "TRAVIS", "") == "true" && !haskey(ENV, "GITHUB_API_TOKEN")
+    @info "Skipping web tests on Travis CI (credentials are unavailable)"
+else
+    include("webui.jl")
+end
 
 end

--- a/test/webui.jl
+++ b/test/webui.jl
@@ -154,16 +154,15 @@ const config = Dict(
             @test resp.status == 400
             @test occursin("Branch was not provided", String(resp.body))
 
-            body = "package=https://github.com/foo/bar&ref=master"
+            body = "package=https://github.com/JuliaLang/NotARealRepo&ref=master"
             resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
             @test resp.status == 400
             @test occursin("Repository was not found", String(resp.body))
 
-            # # This is an actual repository, it hasn't been touched for >5 years.
-            # body = "package=http://github.com/foo/ii&ref=master"
-            # resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
-            # @test resp.status == 400
-            # @test occursin("Unauthorized to release this package", String(resp.body))
+            body = "package=http://github.com/JuliaLang/julia&ref=master"
+            resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
+            @test resp.status == 400
+            @test occursin("Unauthorized to release this package", String(resp.body))
         end
     end
 end


### PR DESCRIPTION
Turns out we should use repositories that we know will continue to exist as test examples :upside_down_face:. 
A bit of relevant discussion in #131.