### PR TITLE
Fix GitLab permissions, method types, and remove unused method

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -55,9 +55,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[GitForge]]
 deps = ["Dates", "HTTP", "JSON2"]
-git-tree-sha1 = "5ae8a43266447e6105d14811655a839539f09e12"
+git-tree-sha1 = "5f76d938f3f5e2665b234854cd7303124c5f6634"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
-version = "0.1.0"
+version = "0.1.1"
 
 [[GitHub]]
 deps = ["Base64", "Compat", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "Test"]
@@ -153,9 +153,9 @@ version = "1.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "6eae3454d1fd3097b1e5d81dbe11db849225cb8b"
+git-tree-sha1 = "e2e65679cc0b70f2baeb504c8d99c2fc6d1a5cdc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.2"
+version = "0.3.3"
 
 [[Pidfile]]
 deps = ["FileWatching", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,9 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TimeToLive = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
+[compat]
+GitForge = ">= 0.1.1"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/README.web.md
+++ b/README.web.md
@@ -108,8 +108,9 @@ There are some that are required, and some that are optional.
   You should only set this if provider is one you added yourself or has a URL that does not contain `github` or `gitlab`.
   For GitHub, the value should be `github`, and for GitLab, it should be `gitlab`.
   For any other provider, it should be whatever key you used in your extra providers file.
+- `REGISTRY_DEPS`: The URLs (space-delimited) of any registries that packages in your target registry depend on.
 - `ROUTE_PREFIX`: Base route for the server.
-  Ex: set `ROUTE_PREFIX=/registrator` to serve the UI on `<your-hostname>/registrator/`.
+  For example, use `/registrator` to serve the UI on `<your-hostname>/registrator/`.
   
 ## Adding Extra Providers
 

--- a/README.web.md
+++ b/README.web.md
@@ -109,6 +109,7 @@ There are some that are required, and some that are optional.
   For GitHub, the value should be `github`, and for GitLab, it should be `gitlab`.
   For any other provider, it should be whatever key you used in your extra providers file.
 - `REGISTRY_DEPS`: The URLs (space-delimited) of any registries that packages in your target registry depend on.
+- `DISABLE_PATCH_NOTES`: Set to `true` to disable the patch notes text box.
 - `ROUTE_PREFIX`: Base route for the server.
   For example, use `/registrator` to serve the UI on `<your-hostname>/registrator/`.
   

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -443,7 +443,7 @@ function get_clone_url(event)
 end
 
 
-function is_pfile_parseable(c::String)
+function is_pfile_parseable(c::AbstractString)
     @debug("Checking whether Project.toml is non-empty and parseable")
     if length(c) != 0
         try
@@ -489,7 +489,7 @@ function is_pfile_nuv(c)
     return true, nothing
 end
 
-function is_pfile_valid(c::String)
+function is_pfile_valid(c::AbstractString)
     for f in [is_pfile_parseable, is_pfile_nuv]
         v, err = f(c)
         v || return v, err
@@ -542,7 +542,7 @@ function get_jwt_auth()
     GitHub.JWTAuth(config["github"]["app_id"], config["github"]["priv_pem"])
 end
 
-function make_comment(evt::WebhookEvent, body::String)
+function make_comment(evt::WebhookEvent, body::AbstractString)
     config["registrator"]["reply_comment"] || return
     @debug("Posting comment to PR/issue")
     headers = Dict("private_token" => config["github"]["token"])

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -12,7 +12,7 @@ using JSON
 using MbedTLS
 
 import Pkg: TOML
-import ..Registrator: post_on_slack_channel
+import ..Registrator: post_on_slack_channel, pull_request_contents
 import ..RegEdit: register, RegBranch
 import Base: string
 

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -761,7 +761,7 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         package=name,
         repo=rp.evt.repository.html_url,
         user="@$creator",
-        branch=brn,
+        gitref=brn,
         version=ver,
         commit=pp.sha,
         patch_notes=rp.patch_notes,

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -170,10 +170,10 @@ end
 function isauthorized(u::User{GitLab.User}, repo::GitLab.Project)
     repo.visibility == "private" && return false
     forge = PROVIDERS["gitlab"].client
-    hasauth = @gf if repo.namespace == "user"
-        is_member(forge, repo.namespace.full_path, u.user.id)
-    else
+    hasauth = @gf if repo.namespace.kind == "user"
         is_collaborator(forge, repo.owner.username, repo.name, u.user.id)
+    else
+        is_member(forge, repo.namespace.full_path, u.user.id)
     end
     return something(hasauth, false)
 end

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -1,6 +1,6 @@
 module WebUI
 
-using ..Registrator: RegEdit
+using ..Registrator: RegEdit, pull_request_contents
 
 using Base64
 using Dates

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -21,27 +21,6 @@ ROUTE_REGISTER = "/register"
 
 const DOCS = "https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.web.md#usage-for-package-maintainers"
 
-const PAGE_SELECT = """
-    <script>
-    function disableButton() {
-      var button = document.getElementById("submitButton");
-      button.disabled = true;
-      button.value = "Please wait...";
-    }
-    </script>
-    <form action="$ROUTE_REGISTER" method="post" onsubmit="disableButton()">
-    URL of package to register: <input type="text" size="50" name="package">
-    <br>
-    Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
-    <br>
-    Patch notes (optional):
-    <br>
-    <textarea cols="80" rows="10" name="notes"></textarea>
-    <br>
-    <input id="submitButton" type="submit" value="Submit">
-    </form>
-    """
-
 # A supported provider whose hosted repositories can be registered.
 Base.@kwdef struct Provider{F <: GitForge.Forge}
     name::String
@@ -370,7 +349,29 @@ function callback(r::HTTP.Request)
 end
 
 # Step 4: Select a package.
-select(::HTTP.Request) = html(PAGE_SELECT)
+function select(::HTTP.Request)
+    body = """
+        <script>
+        function disableButton() {
+          var button = document.getElementById("submitButton");
+          button.disabled = true;
+          button.value = "Please wait...";
+        }
+        </script>
+        <form action="$ROUTE_REGISTER" method="post" onsubmit="disableButton()">
+        URL of package to register: <input type="text" size="50" name="package">
+        <br>
+        Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
+        <br>
+        Patch notes (optional):
+        <br>
+        <textarea cols="80" rows="10" name="notes"></textarea>
+        <br>
+        <input id="submitButton" type="submit" value="Submit">
+        </form>
+        """
+    return html(body)
+end
 
 # Step 5: Register the package (maybe).
 function register(r::HTTP.Request)

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -22,7 +22,14 @@ ROUTE_REGISTER = "/register"
 const DOCS = "https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.web.md#usage-for-package-maintainers"
 
 const PAGE_SELECT = """
-    <form action="$ROUTE_REGISTER" method="post">
+    <script>
+    function disableButton() {
+      var button = document.getElementById("submitButton");
+      button.disabled = true;
+      button.value = "Please wait...";
+    }
+    </script>
+    <form action="$ROUTE_REGISTER" method="post" onsubmit="disableButton()">
     URL of package to register: <input type="text" size="50" name="package">
     <br>
     Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
@@ -31,7 +38,7 @@ const PAGE_SELECT = """
     <br>
     <textarea cols="80" rows="10" name="notes"></textarea>
     <br>
-    <input type="submit" value="Submit">
+    <input id="submitButton" type="submit" value="Submit">
     </form>
     """
 

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -41,6 +41,7 @@ struct Registry{F <: GitForge.Forge, R}
     url::String
     clone::String
     deps::Vector{String}
+    enable_patch_notes::Bool
 end
 
 # U is a User type, e.g. GitHub.User.
@@ -363,13 +364,22 @@ function select(::HTTP.Request)
         <br>
         Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
         <br>
-        Patch notes (optional):
-        <br>
-        <textarea cols="80" rows="10" name="notes"></textarea>
-        <br>
+        """
+
+    if REGISTRY[].enable_patch_notes
+        body *= """
+            Patch notes (optional):
+            <br>
+            <textarea cols="80" rows="10" name="notes"></textarea>
+            <br>
+            """
+    end
+
+    body *= """
         <input id="submitButton" type="submit" value="Submit">
         </form>
         """
+
     return html(body)
 end
 
@@ -507,7 +517,8 @@ function init_registry()
     repo === nothing && error("Registry lookup failed")
     clone = get(ENV, "REGISTRY_CLONE_URL", url)
     deps = Vector{String}(split(get(ENV, "REGISTRY_DEPS", "")))
-    REGISTRY[] = Registry(forge, repo, url, clone, deps)
+    enable_patch_notes = get(ENV, "DISABLE_PATCH_NOTES", "") != "true"
+    REGISTRY[] = Registry(forge, repo, url, clone, deps, enable_patch_notes)
 end
 
 for f in [:index, :auth, :callback, :select, :register]

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -235,6 +235,7 @@ function make_registration_request(
         target_branch=r.repo.default_branch,
         title=title,
         description=body,
+        remove_source_branch=true,
     )
 end
 

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -25,7 +25,7 @@ const PAGE_SELECT = """
     <form action="$ROUTE_REGISTER" method="post">
     URL of package to register: <input type="text" size="50" name="package">
     <br>
-    Branch to register: <input type="text" size="20" name="ref" value="master">
+    Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
     <br>
     Patch notes (optional):
     <br>
@@ -220,8 +220,8 @@ function gettreesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
     return try
         mktempdir() do dir
             dest = joinpath(dir, r.name)
-            run(`git clone $url $dest --branch $ref`)
-            match(r"tree (.*)", readchomp(`git -C $dest show HEAD --format=raw`))[1]
+            run(`git clone $url $dest`)
+            match(r"tree (.*)", readchomp(`git -C $dest show $ref --format=raw`))[1]
         end
     catch
         nothing
@@ -422,7 +422,7 @@ function register(r::HTTP.Request)
             package=project.name,
             repo=web_url(repo),
             user=display_user(u.user),
-            branch=ref,
+            gitref=ref,
             version=project.version,
             commit=commit,
             patch_notes=notes,

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -211,11 +211,11 @@ cloneurl(r::GitHub.Repo) = r.clone_url
 cloneurl(r::GitLab.Project) = r.http_url_to_repo
 
 # Get a repo's tree hash.
-function treesha(f::GitHubAPI, r::GitHub.Repo, ref::AbstractString)
+function gettreesha(f::GitHubAPI, r::GitHub.Repo, ref::AbstractString)
     branch = @gf get_branch(f, r.owner.login, r.name, ref)
     return branch === nothing ? nothing : branch.commit.commit.tree.sha
 end
-function treesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
+function gettreesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
     url = cloneurl(r)
     return try
         mktempdir() do dir
@@ -409,7 +409,7 @@ function register(r::HTTP.Request)
     # Register the package,
     clone = cloneurl(repo)
     project = Pkg.Types.read_project(IOBuffer(toml))
-    tree = treesha(u.forge, repo, ref)
+    tree = gettreesha(u.forge, repo, ref)
     tree === nothing && return html(500, "Looking up the tree hash failed")
     branch = RegEdit.register(
         clone, project, tree;

--- a/src/pull_request.jl
+++ b/src/pull_request.jl
@@ -6,7 +6,7 @@ function pull_request_contents(;
     package::AbstractString,
     repo::AbstractString,
     user::AbstractString,
-    branch::AbstractString,
+    gitref::AbstractString,
     version::VersionNumber,
     commit::AbstractString,
     patch_notes::AbstractString,
@@ -25,7 +25,7 @@ function pull_request_contents(;
         "- Registering package: $package",
         "- Repository: $repo",
         "- Created by: $user",
-        "- Branch: $branch",
+        "- Git reference: $gitref",
         "- Version: v$version",
         "- Commit: $commit",
     ]

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -451,7 +451,7 @@ errors or warnings that occurred.
 function register(
     package_repo::AbstractString, pkg::Pkg.Types.Project, tree_hash::AbstractString;
     registry::AbstractString = DEFAULT_REGISTRY_URL,
-    registry_deps::Vector{<:AbstractString} = String[],
+    registry_deps::Vector{<:AbstractString} = [],
     push::Bool = false,
     gitconfig::Dict = Dict()
 )

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -36,7 +36,7 @@ end
 Given a remote repo URL and a git tree spec, get a `Project` object
 for the project file in that tree and a hash string for the tree.
 """
-# function get_project(remote_url::String, tree_spec::String)
+# function get_project(remote_url::AbstractString, tree_spec::AbstractString)
 #     # TODO?: use raw file downloads for GitHub/GitLab
 #     mktempdir(mkpath("packages")) do tmp
 #         # bare clone the package repo
@@ -90,12 +90,12 @@ struct RegBranch
 
     metadata::Dict{String,Any} # "error", "warning", kind etc.
 
-    function RegBranch(pkg::Pkg.Types.Project, branch::String)
+    function RegBranch(pkg::Pkg.Types.Project, branch::AbstractString)
         new(pkg.name, pkg.version, branch, Dict{String,Any}())
     end
 end
 
-function write_registry(registry_path::String, reg::RegistryData)
+function write_registry(registry_path::AbstractString, reg::RegistryData)
     open(registry_path, "w") do io
         TOML.print(io, reg)
     end
@@ -145,10 +145,10 @@ function check_version!(regbr::RegBranch, existing::Vector{VersionNumber}, ver::
     return regbr
 end
 
-findpackageerror(name::String, uuid::Base.UUID, regdata::Array{RegistryData}) =
+findpackageerror(name::AbstractString, uuid::Base.UUID, regdata::Array{RegistryData}) =
     findpackageerror(name, string(uuid), regdata)
 
-function findpackageerror(name::String, u::String, regdata::Array{RegistryData})
+function findpackageerror(name::AbstractString, u::AbstractString, regdata::Array{RegistryData})
     for _registry_data in regdata
         if haskey(_registry_data.packages, u)
             name_in_reg = _registry_data.packages[u]["name"]
@@ -215,7 +215,7 @@ end
 
 import Pkg.Compress.load_versions
 
-function compress(path::String, uncompressed::Dict,
+function compress(path::AbstractString, uncompressed::Dict,
     versions::Vector{VersionNumber} = load_versions(path))
     inverted = Dict()
     for (ver, data) in uncompressed, (key, val) in data
@@ -231,7 +231,7 @@ function compress(path::String, uncompressed::Dict,
     return compressed
 end
 
-function save(path::String, uncompressed::Dict,
+function save(path::AbstractString, uncompressed::Dict,
     versions::Vector{VersionNumber} = load_versions(path))
     compressed = compress(path, uncompressed)
     open(path, write=true) do io
@@ -242,9 +242,9 @@ end
 # ---- End of code copied from Pkg
 
 function find_package_in_registry(pkg::Pkg.Types.Project,
-                                  package_repo::String,
-                                  registry_file::String,
-                                  registry_path::String,
+                                  package_repo::AbstractString,
+                                  registry_file::AbstractString,
+                                  registry_path::AbstractString,
                                   registry_data::RegistryData,
                                   regbr::RegBranch)
     uuid = string(pkg.uuid)
@@ -290,8 +290,8 @@ function find_package_in_registry(pkg::Pkg.Types.Project,
 end
 
 function update_package_file(pkg::Pkg.Types.Project,
-                             package_repo::String,
-                             package_path::String)
+                             package_repo::AbstractString,
+                             package_path::AbstractString)
     package_info = Dict("name" => pkg.name,
                         "uuid" => string(pkg.uuid),
                         "repo" => package_repo)
@@ -304,9 +304,9 @@ function update_package_file(pkg::Pkg.Types.Project,
 end
 
 function update_versions_file(pkg::Pkg.Types.Project,
-                              package_path::String,
+                              package_path::AbstractString,
                               regbr::RegBranch,
-                              tree_hash::String)
+                              tree_hash::AbstractString)
     versions_file = joinpath(package_path, "Versions.toml")
     versions_data = isfile(versions_file) ? TOML.parsefile(versions_file) : Dict()
     versions = sort!([VersionNumber(v) for v in keys(versions_data)])
@@ -326,7 +326,7 @@ function update_versions_file(pkg::Pkg.Types.Project,
 end
 
 function update_deps_file(pkg::Pkg.Types.Project,
-                          package_path::String,
+                          package_path::AbstractString,
                           regbr::RegBranch,
                           regdata::Vector{RegistryData})
     if pkg.name in keys(pkg.deps)
@@ -359,7 +359,7 @@ function update_deps_file(pkg::Pkg.Types.Project,
 end
 
 function update_compat_file(pkg::Pkg.Types.Project,
-                            package_path::String,
+                            package_path::AbstractString,
                             regbr::RegBranch,
                             regdata::Vector{RegistryData},
                             regpaths::Vector{String})
@@ -470,13 +470,13 @@ errors or warnings that occurred.
 
 # Arguments
 
-* `package_repo::String`: the git repository URL for the package to be registered
+* `package_repo::AbstractString`: the git repository URL for the package to be registered
 * `pkg::Pkg.Types.Project`: the parsed Project.toml file for the package to be registered
-* `tree_hash::String`: the tree hash (not commit hash) of the package revision to be registered
+* `tree_hash::AbstractString`: the tree hash (not commit hash) of the package revision to be registered
 
 # Keyword Arguments
 
-* `registry::String="$DEFAULT_REGISTRY_URL"`: the git repository URL for the registry
+* `registry::AbstractString="$DEFAULT_REGISTRY_URL"`: the git repository URL for the registry
 * `registry_deps::Vector{String}=[]`: the git repository URLs for any registries containing
     packages depended on by `pkg`
 * `push::Bool=false`: whether to push a registration branch to `registry` for consideration
@@ -484,7 +484,7 @@ errors or warnings that occurred.
 """
 function register(
     package_repo::AbstractString, pkg::Pkg.Types.Project, tree_hash::AbstractString;
-    registry::String = DEFAULT_REGISTRY_URL,
+    registry::AbstractString = DEFAULT_REGISTRY_URL,
     registry_deps::Vector{<:AbstractString} = String[],
     push::Bool = false,
     gitconfig::Dict = Dict()
@@ -550,7 +550,7 @@ function register(
         @debug("check compat section")
         regpaths = [registry_path; registry_deps_paths]
         r = update_compat_file(pkg, package_path, regbr, regdata, regpaths)
-        r === nothing || return r 
+        r === nothing || return r
 
         regtreesha = get_registrator_tree_sha()
 

--- a/src/regedit/types.jl
+++ b/src/regedit/types.jl
@@ -28,7 +28,7 @@ Return a `GitRepo` object for an up-to-date copy of `registry`.
 Update the existing copy if available.
 """
 function get_registry(
-    registry_url::String;
+    registry_url::AbstractString;
     gitconfig::Dict=Dict(),
     cache::RegistryCache=REGISTRY_CACHE,
 )


### PR DESCRIPTION
First: Some GitLab permission checks were incorrect, I believe that they work properly now.

Second: I was passing in a `SubString` at some point which broke things, there's no downside to accepting other types of strings.

Third: The second change exposed some duplicate code which was probably the result of a bad rebase by me. I think I removed the right one, since the `RegistryCache` seems newer.

Closes #140 