### PR TITLE
WebUI: Use a TOML configuration file instead of environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /tmp
 /registries
 /packages
-*.env
+*.secret.toml

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -55,9 +55,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[GitForge]]
 deps = ["Dates", "HTTP", "JSON2"]
-git-tree-sha1 = "5ae8a43266447e6105d14811655a839539f09e12"
+git-tree-sha1 = "5f76d938f3f5e2665b234854cd7303124c5f6634"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
-version = "0.1.0"
+version = "0.1.1"
 
 [[GitHub]]
 deps = ["Base64", "Compat", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "Test"]
@@ -153,9 +153,9 @@ version = "1.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "6eae3454d1fd3097b1e5d81dbe11db849225cb8b"
+git-tree-sha1 = "e2e65679cc0b70f2baeb504c8d99c2fc6d1a5cdc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.2"
+version = "0.3.3"
 
 [[Pidfile]]
 deps = ["FileWatching", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,9 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TimeToLive = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
+[compat]
+GitForge = ">= 0.1.1"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/README.web.md
+++ b/README.web.md
@@ -108,8 +108,9 @@ There are some that are required, and some that are optional.
   You should only set this if provider is one you added yourself or has a URL that does not contain `github` or `gitlab`.
   For GitHub, the value should be `github`, and for GitLab, it should be `gitlab`.
   For any other provider, it should be whatever key you used in your extra providers file.
+- `REGISTRY_DEPS`: The URLs (space-delimited) of any registries that packages in your target registry depend on.
 - `ROUTE_PREFIX`: Base route for the server.
-  Ex: set `ROUTE_PREFIX=/registrator` to serve the UI on `<your-hostname>/registrator/`.
+  For example, use `/registrator` to serve the UI on `<your-hostname>/registrator/`.
   
 ## Adding Extra Providers
 

--- a/README.web.md
+++ b/README.web.md
@@ -70,55 +70,66 @@ Git must be installed on the host computer.
 Additionally, it must be configured so that it can push to the registry, preferably as the user you just created.
 You should make sure that you've set up any credential handling such as SSH keys.
 
-## Environment Variables
+## Configuration
 
-Registrator configuration is done mostly with environment variables.
-There are some that are required, and some that are optional.
+Registrator configuration is done with a config file.
+Some of its values are required, and some are optional.
+It's important to note that optional values **must** be omitted or commented out when not in use.
 
-### Required
+### `[web]` Section
 
-- `GIT{HUB,LAB}_API_TOKEN`: Your user's API key.
-- `GIT{HUB,LAB}_CLIENT_ID`: Your OAuth2 application's client ID.
-- `GIT{HUB,LAB}_CLIENT_SECRET`: Your OAuth2 application's client secret.
-- `SERVER_URL`: The URL at which your server is accessible.
+#### Required
+
+- `ip`: The address that your server will listen on.
+  For example, `localhost` or `0.0.0.0`.
+- `port`: The port that your server will listen to.
+- `server_url`: The full URL at which your server will be accessible.
   This could be something like `http://localhost:4000` for testing, or `https://example.com`.
-- `REGISTRY_URL`: Your registry repository's web URL, for example `https://github.com/foo/bar`.
+- `registry_url`: Your registry repository's web URL, for example `https://github.com/foo/bar`.
 
-### Optional
+#### Optional
 
-- `REGISTRY_CLONE_URL`: Your registry's clone URL.
-  This defaults to the previous URL.
-  You can use this variable to clone the registry via SSH, for example.
-- `GIT{HUB,LAB}_API_URL`: Provider API base URL.
-  You should only set this variable if your provider is self-hosted (i.e. with a non-default URL).
-- `GIT{HUB,LAB}_AUTH_URL`: OAuth2 authentication URL.
-  Only set this for self-hosted providers.
-- `GIT{HUB,LAB}_TOKEN_URL`: OAuth2 token exchange URL.p
-  Only set this for self-hosted providers.
-- `GIT{HUB,LAB}_DISABLE_RATE_LIMITS`: Set to `true` to disable rate limit processing.
-  Only set this for self-hosted instances that don't use rate limiting.
-- `DISABLED_PROVIDERS`: A space-delimited list of providers to disable.
-  If you disable a provider, then you don't need any of its prerequisites mentioned above.
-  However, users won't be able to register packages from that provider.
-  Use `github` to disable GitHub and `gitlab` to disable GitLab.
-- `EXTRA_PROVIDERS`: Path to a Julia file that adds extra providers.
+- `registry_clone_url`: Your registry's clone URL.
+  This defaults to `registry_url`, but you can use this value to clone the registry via SSH, for example.
+- `extra_providers`: Path to a Julia file that adds extra providers.
   This should only be used for certain cases when your provider is self-hosted (see next section).
-- `REGISTRY_PROVIDER`: The registry provider.
-  This is optional, and can usually be inferred from the registry URL.
+- `registry_provider`: The registry provider, which is usually inferred from the registry URL.
   You should only set this if provider is one you added yourself or has a URL that does not contain `github` or `gitlab`.
   For GitHub, the value should be `github`, and for GitLab, it should be `gitlab`.
   For any other provider, it should be whatever key you used in your extra providers file.
-- `REGISTRY_DEPS`: The URLs (space-delimited) of any registries that packages in your target registry depend on.
-- `DISABLE_PATCH_NOTES`: Set to `true` to disable the patch notes text box.
-- `ROUTE_PREFIX`: Base route for the server.
+- `registry_deps`: A list of URLs representing any registries that your target registry depends on.
+- `disable_patch_notes`: Set to `true` to disable the patch notes text box.
+- `route_prefix`: Base route for the server.
   For example, use `/registrator` to serve the UI on `<your-hostname>/registrator/`.
   
+### `[web.git{hub,lab}]` Section
+
+If you want to disable a provider, simply omit its section.
+For example, to support GitHub packages but not GitLab packages, only provide a `[web.github]` section.
+
+#### Required
+
+- `token`: Your user's API key.
+- `client_id`: Your OAuth2 application's client ID.
+- `client_secret`: Your OAuth2 application's client secret.
+
+#### Optional
+
+- `api_url`: Provider API base URL.
+  You should only set this variable if your provider is self-hosted (i.e. with a non-default URL).
+- `auth_url`: OAuth2 authentication URL.
+  Only set this for self-hosted providers.
+- `token_url`: OAuth2 token exchange URL.p
+  Only set this for self-hosted providers.
+- `disable_rate_limits`: Set to `true` to disable rate limit processing.
+  Only set this for self-hosted instances that don't use rate limiting.
+
 ## Adding Extra Providers
 
 In almost all cases, you shouldn't need to do this.
 The only real use case is when your registry is on a self-hosted GitHub or GitLab instance, and you also want to allow registering of packages from the public instance of that provider.
 The only two providers supported are GitHub and GitLab.
-If you do want to do this, then you should set the `EXTRA_PROVIDERS` variable mentioned above.
+If you do want to do this, then you should set `web.extra_providers` as mentioned above.
 The file should look like this:
 
 ```julia
@@ -152,7 +163,7 @@ PROVIDERS["mygitlab"] = Provider(;
 ```
 
 - `name`: The text displayed on the authentication link.
-- `client`: A [GitForge](https://cdg.dev/GitForge.jl/dev) `Forge` with access to your provider.
+- `client`: A [GitForge](https://cdg.dev/GitForge.jl/stable) `Forge` with access to your provider.
 - `scope`: Use `public_repo` for GitHub and `read_user` for GitLab.
 - `include_state`: Leave out for GitHub and set `false` for GitLab.
 - `token_type`: Leave out for GitHub and set `OAuth2Token` for GitLab.
@@ -163,7 +174,7 @@ When setting your OAuth2 application's callback URL, make sure that it ends with
 ## Running the Server
 
 To run the server, first add Registrator to your Julia environment.
-Then, make sure that all environment variables are set correctly.
+Then, make sure that your configuration file is written correctly.
 The following code will start the server:
 
 ```julia
@@ -178,33 +189,43 @@ It's not important to keep it intact, as it is synchronized before registering a
 
 Here's a general case of hosting a registry on GitHub and allowing package registrations from both GitHub and GitLab.
 The registry will be owned by `RegistryOwner` and the name will be `MyRegistry`.
-The web server will be hosted at `https://myregistrator.com`.
+The web server will be hosted at `https://myregistrator.com`, and run on port 4000.
 
-The first thing we'll do is set up a `.env` file with some information we already have.
+The first thing we'll do is set up a `config.toml` file with some information we already have.
 
-```sh
-#!/usr/bin/env sh
+Note that in this and any following examples, the section names (i.e. `[web]`) will always be included for clarity.
+However, they should only appear once in the final file.
 
-export SERVER_URL="https://myregistrator.com"
-export REGISTRY_URL="https://github.com/RegistryOwner/MyRegistry"
+```toml
+[web]
+ip = "0.0.0.0"
+port = 4000
+server_url = "https://myregistrator.com"
+registry_url = "https://github.com/RegistryOwner/MyRegistry"
 ```
 
 Next, we create the GitHub and GitLab users and API keys, and save those API keys:
 
-```sh
-export GITHUB_API_TOKEN="abc..."
-export GITLAB_API_TOKEN="abc..."
+```toml
+[web.github]
+token = "abc..."
+
+[web.gitlab]
+token = "abc..."
 ```
 
 Next, create OAuth2 applications for both of them.
 The callback URLs will be `https://myregistrator.com/callback?provider=github` and `https://myregistrator.com/callback?provider=gitlab`.
 Add the client IDs and secrets to our file:
 
-```sh
-export GITHUB_CLIENT_ID="abc..."
-export GITLAB_CLIENT_ID="abc..."
-export GITHUB_CLIENT_SECRET="abc..."
-export GITLAB_CLIENT_SECRET="abc..."
+```toml
+[web.github]
+client_id = "abc..."
+client_secret = "abc..."
+
+[web.gitlab]
+client_id = "abc..."
+client_secret = "abc..."
 ```
 
 Now let's configure Git and set up SSH authentication to GitHub.
@@ -221,25 +242,46 @@ Now go to GitHub user settings and add the public key to your new user.
 
 To actually use this key, we'll set the clone URL for our registry in `.env`:
 
-```sh
-export REGISTRY_CLONE_URL="git@github.com:RegistryOwner/MyRegistry.git"
+```toml
+[web]
+registry_clone_url = "git@github.com:RegistryOwner/MyRegistry.git"
+```
+
+Our file is finished, and looks like this:
+
+```toml
+[web]
+ip = "0.0.0.0"
+port = 4000
+server_url = "https://myregistrator.com"
+registry_url = "https://github.com/RegistryOwner/MyRegistry"
+registry_clone_url = "git@github.com:RegistryOwner/MyRegistry.git"
+
+[web.github]
+token = "abc..."
+client_id = "abc..."
+client_secret = "abc..."
+
+[web.gitlab]
+token = "abc..."
+client_id = "abc..."
+client_secret = "abc..."
 ```
 
 Now that this is done, we're ready to run the server.
-
-Install Registrator, apply the environment variables, and run Julia with the server on port 4000:
+Since our config file is at the default location (`config.toml`), we don't need to pass any arguments.
 
 ```sh
+# Instalation: Just do this once.
 julia -e '
     using Pkg; 
-    Pkg.add("https://github.com/JuliaRegistries/Registrator.jl")''
-source .env
+    Pkg.add("https://github.com/JuliaRegistries/Registrator.jl")'
+
+# Run this every time.
 julia -e '
     using Registrator;
-    Registrator.WebUI.main(; port=4000)'
+    Registrator.WebUI.main()'
 ```
-
-<!-- TODO: I have no idea how domains, certificates, etc. work. -->
 
 ## Basic Recipe: Private Registry
 
@@ -248,39 +290,47 @@ This guide will be almost identical to the one above, but we'll set up a private
 Let's assume we're running a GitLab instance at `https://git.corp.com`, and our repo is at `Registries/General`.
 We want to host our instance at `https://registrator.corp.com`.
 
-First, let's again start off with a `.env` file.
+First, let's again start off with a TOML file, but this time at `myconfig.toml`:
 
-```sh
-#!/usr/bin/env sh
+```toml
+[web]
+registry_provider = "gitlab"
 
-export DISABLED_PROVIDERS="github"
-export REGISTRY_PROVIDER="gitlab"
-export GITLAB_API_URL="https://git.corp.com/api/v4"
-export GITLAB_AUTH_URL="https://git.corp.com/oauth/authorize"
-export GITLAB_TOKEN_URL="https://git.corp.com/oauth/token"
-export REGISTRY_URL="https://git.corp.com/Registries/General"
-export SERVER_URL="https://registrator.corp.com"
+[web.gitlab]
+api_url = "https://git.corp.com/api/v4"
+auth_url = "https://git.corp.com/oauth/authorize"
+token_url = "https://git.corp.com/oauth/token"
+registry_url = "https://git.corp.com/Registries/General"
+server_url = "https://registrator.corp.com"
 ```
 
-We had to set a few URLs manually, and we also disabled GitHub.
-Additionally, we set `REGISTRY_PROVIDER="gitlab"` because the string "gitlab" does not occur in our registry's URL.
+As you can see, We had to set a few URLs manually.
+Additionally, we set `registry_provider = "gitlab"` because the string "gitlab" does not occur in our registry's URL.
 
 Next, we create our user, API key, and OAuth application.
 Make sure to enable the `read_user` scope, and to set the callback URL to `https://registrator.corp.com/callback?provider=gitlab`.
 
-Add our credentials to the `.env`:
+Add our credentials to the file:
 
-```sh
-export GITLAB_API_TOKEN="abc..."
-export GITLAB_CLIENT_ID="abc..."
-export GITLAB_CLIENT_SECRET="abc..."
+```toml
+[web.gitlab]
+token = "abc..."
+client_id = "abc..."
+client_secret = "abc..."
 ```
 
 We'll do the same Git configuration as before, and set our clone URL appropriately:
 
-```sh
-export REGISTR_CLONE_URL="git@git.corp.com:Registries/General"
+```toml
+[web]
+registry_clone_url = "git@git.corp.com:Registries/General"
 ```
 
 And then we're ready.
-With the same commands as before, we can run our server!
+We can run it in the same way as before, but passing our non-default config path:
+
+```sh
+julia -e '
+    using Registrator;
+    Registrator.WebUI.main("myconfig.toml")'
+```

--- a/README.web.md
+++ b/README.web.md
@@ -109,6 +109,7 @@ There are some that are required, and some that are optional.
   For GitHub, the value should be `github`, and for GitLab, it should be `gitlab`.
   For any other provider, it should be whatever key you used in your extra providers file.
 - `REGISTRY_DEPS`: The URLs (space-delimited) of any registries that packages in your target registry depend on.
+- `DISABLE_PATCH_NOTES`: Set to `true` to disable the patch notes text box.
 - `ROUTE_PREFIX`: Base route for the server.
   For example, use `/registrator` to serve the UI on `<your-hostname>/registrator/`.
   

--- a/config.web.toml
+++ b/config.web.toml
@@ -1,0 +1,31 @@
+# See README.web.md for details on each key.
+
+[web]
+ip = ""
+port = 0
+server_url = ""
+registry_url = ""
+# registry_clone_url = ""
+# extra_providers = ""
+# registry_provider = ""
+# registry_deps = []
+# disable_patch_notes = false
+# route_prefix = ""
+
+[web.github]
+token = ""
+client_id = ""
+client_secret = ""
+# api_url = ""
+# auth_url = ""
+# token_url = ""
+# disable_rate_limits = false
+
+[web.gitlab]
+token = ""
+client_id = ""
+client_secret = ""
+# api_url = ""
+# auth_url = ""
+# token_url = ""
+# disable_rate_limits = false

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -443,7 +443,7 @@ function get_clone_url(event)
 end
 
 
-function is_pfile_parseable(c::String)
+function is_pfile_parseable(c::AbstractString)
     @debug("Checking whether Project.toml is non-empty and parseable")
     if length(c) != 0
         try
@@ -489,7 +489,7 @@ function is_pfile_nuv(c)
     return true, nothing
 end
 
-function is_pfile_valid(c::String)
+function is_pfile_valid(c::AbstractString)
     for f in [is_pfile_parseable, is_pfile_nuv]
         v, err = f(c)
         v || return v, err
@@ -542,7 +542,7 @@ function get_jwt_auth()
     GitHub.JWTAuth(config["github"]["app_id"], config["github"]["priv_pem"])
 end
 
-function make_comment(evt::WebhookEvent, body::String)
+function make_comment(evt::WebhookEvent, body::AbstractString)
     config["registrator"]["reply_comment"] || return
     @debug("Posting comment to PR/issue")
     headers = Dict("private_token" => config["github"]["token"])

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -12,7 +12,7 @@ using JSON
 using MbedTLS
 
 import Pkg: TOML
-import ..Registrator: post_on_slack_channel
+import ..Registrator: post_on_slack_channel, pull_request_contents
 import ..RegEdit: register, RegBranch
 import Base: string
 

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -761,7 +761,7 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         package=name,
         repo=rp.evt.repository.html_url,
         user="@$creator",
-        branch=brn,
+        gitref=brn,
         version=ver,
         commit=pp.sha,
         patch_notes=rp.patch_notes,

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -170,10 +170,10 @@ end
 function isauthorized(u::User{GitLab.User}, repo::GitLab.Project)
     repo.visibility == "private" && return false
     forge = PROVIDERS["gitlab"].client
-    hasauth = @gf if repo.namespace == "user"
-        is_member(forge, repo.namespace.full_path, u.user.id)
-    else
+    hasauth = @gf if repo.namespace.kind == "user"
         is_collaborator(forge, repo.owner.username, repo.name, u.user.id)
+    else
+        is_member(forge, repo.namespace.full_path, u.user.id)
     end
     return something(hasauth, false)
 end

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -1,6 +1,6 @@
 module WebUI
 
-using ..Registrator: RegEdit
+using ..Registrator: RegEdit, pull_request_contents
 
 using Base64
 using Dates

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -21,27 +21,6 @@ ROUTE_REGISTER = "/register"
 
 const DOCS = "https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.web.md#usage-for-package-maintainers"
 
-const PAGE_SELECT = """
-    <script>
-    function disableButton() {
-      var button = document.getElementById("submitButton");
-      button.disabled = true;
-      button.value = "Please wait...";
-    }
-    </script>
-    <form action="$ROUTE_REGISTER" method="post" onsubmit="disableButton()">
-    URL of package to register: <input type="text" size="50" name="package">
-    <br>
-    Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
-    <br>
-    Patch notes (optional):
-    <br>
-    <textarea cols="80" rows="10" name="notes"></textarea>
-    <br>
-    <input id="submitButton" type="submit" value="Submit">
-    </form>
-    """
-
 # A supported provider whose hosted repositories can be registered.
 Base.@kwdef struct Provider{F <: GitForge.Forge}
     name::String
@@ -370,7 +349,29 @@ function callback(r::HTTP.Request)
 end
 
 # Step 4: Select a package.
-select(::HTTP.Request) = html(PAGE_SELECT)
+function select(::HTTP.Request)
+    body = """
+        <script>
+        function disableButton() {
+          var button = document.getElementById("submitButton");
+          button.disabled = true;
+          button.value = "Please wait...";
+        }
+        </script>
+        <form action="$ROUTE_REGISTER" method="post" onsubmit="disableButton()">
+        URL of package to register: <input type="text" size="50" name="package">
+        <br>
+        Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
+        <br>
+        Patch notes (optional):
+        <br>
+        <textarea cols="80" rows="10" name="notes"></textarea>
+        <br>
+        <input id="submitButton" type="submit" value="Submit">
+        </form>
+        """
+    return html(body)
+end
 
 # Step 5: Register the package (maybe).
 function register(r::HTTP.Request)

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -22,7 +22,14 @@ ROUTE_REGISTER = "/register"
 const DOCS = "https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.web.md#usage-for-package-maintainers"
 
 const PAGE_SELECT = """
-    <form action="$ROUTE_REGISTER" method="post">
+    <script>
+    function disableButton() {
+      var button = document.getElementById("submitButton");
+      button.disabled = true;
+      button.value = "Please wait...";
+    }
+    </script>
+    <form action="$ROUTE_REGISTER" method="post" onsubmit="disableButton()">
     URL of package to register: <input type="text" size="50" name="package">
     <br>
     Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
@@ -31,7 +38,7 @@ const PAGE_SELECT = """
     <br>
     <textarea cols="80" rows="10" name="notes"></textarea>
     <br>
-    <input type="submit" value="Submit">
+    <input id="submitButton" type="submit" value="Submit">
     </form>
     """
 

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -41,6 +41,7 @@ struct Registry{F <: GitForge.Forge, R}
     url::String
     clone::String
     deps::Vector{String}
+    enable_patch_notes::Bool
 end
 
 # U is a User type, e.g. GitHub.User.
@@ -363,13 +364,22 @@ function select(::HTTP.Request)
         <br>
         Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
         <br>
-        Patch notes (optional):
-        <br>
-        <textarea cols="80" rows="10" name="notes"></textarea>
-        <br>
+        """
+
+    if REGISTRY[].enable_patch_notes
+        body *= """
+            Patch notes (optional):
+            <br>
+            <textarea cols="80" rows="10" name="notes"></textarea>
+            <br>
+            """
+    end
+
+    body *= """
         <input id="submitButton" type="submit" value="Submit">
         </form>
         """
+
     return html(body)
 end
 
@@ -507,7 +517,8 @@ function init_registry()
     repo === nothing && error("Registry lookup failed")
     clone = get(ENV, "REGISTRY_CLONE_URL", url)
     deps = Vector{String}(split(get(ENV, "REGISTRY_DEPS", "")))
-    REGISTRY[] = Registry(forge, repo, url, clone, deps)
+    enable_patch_notes = get(ENV, "DISABLE_PATCH_NOTES", "") != "true"
+    REGISTRY[] = Registry(forge, repo, url, clone, deps, enable_patch_notes)
 end
 
 for f in [:index, :auth, :callback, :select, :register]

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -206,6 +206,14 @@ function gettreesha(f::GitHubAPI, r::GitHub.Repo, ref::AbstractString)
 end
 function gettreesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
     url = cloneurl(r)
+
+    if REGISTRY[] isa Registry{GitLabAPI}
+        # For private repositories, we need to insert the token into the URL.
+        host = HTTP.URI(url).host
+        token = CONFIG["gitlab"]["token"]
+        url = replace(url, host => "oauth2:$token@$host")
+    end
+
     return try
         mktempdir() do dir
             dest = joinpath(dir, r.name)

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -235,6 +235,7 @@ function make_registration_request(
         target_branch=r.repo.default_branch,
         title=title,
         description=body,
+        remove_source_branch=true,
     )
 end
 

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -25,7 +25,7 @@ const PAGE_SELECT = """
     <form action="$ROUTE_REGISTER" method="post">
     URL of package to register: <input type="text" size="50" name="package">
     <br>
-    Branch to register: <input type="text" size="20" name="ref" value="master">
+    Git reference (branch/tag/commit): <input type="text" size="20" name="ref" value="master">
     <br>
     Patch notes (optional):
     <br>
@@ -220,8 +220,8 @@ function gettreesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
     return try
         mktempdir() do dir
             dest = joinpath(dir, r.name)
-            run(`git clone $url $dest --branch $ref`)
-            match(r"tree (.*)", readchomp(`git -C $dest show HEAD --format=raw`))[1]
+            run(`git clone $url $dest`)
+            match(r"tree (.*)", readchomp(`git -C $dest show $ref --format=raw`))[1]
         end
     catch
         nothing
@@ -422,7 +422,7 @@ function register(r::HTTP.Request)
             package=project.name,
             repo=web_url(repo),
             user=display_user(u.user),
-            branch=ref,
+            gitref=ref,
             version=project.version,
             commit=commit,
             patch_notes=notes,

--- a/src/WebUI.jl
+++ b/src/WebUI.jl
@@ -211,11 +211,11 @@ cloneurl(r::GitHub.Repo) = r.clone_url
 cloneurl(r::GitLab.Project) = r.http_url_to_repo
 
 # Get a repo's tree hash.
-function treesha(f::GitHubAPI, r::GitHub.Repo, ref::AbstractString)
+function gettreesha(f::GitHubAPI, r::GitHub.Repo, ref::AbstractString)
     branch = @gf get_branch(f, r.owner.login, r.name, ref)
     return branch === nothing ? nothing : branch.commit.commit.tree.sha
 end
-function treesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
+function gettreesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
     url = cloneurl(r)
     return try
         mktempdir() do dir
@@ -409,7 +409,7 @@ function register(r::HTTP.Request)
     # Register the package,
     clone = cloneurl(repo)
     project = Pkg.Types.read_project(IOBuffer(toml))
-    tree = treesha(u.forge, repo, ref)
+    tree = gettreesha(u.forge, repo, ref)
     tree === nothing && return html(500, "Looking up the tree hash failed")
     branch = RegEdit.register(
         clone, project, tree;

--- a/src/pull_request.jl
+++ b/src/pull_request.jl
@@ -6,7 +6,7 @@ function pull_request_contents(;
     package::AbstractString,
     repo::AbstractString,
     user::AbstractString,
-    branch::AbstractString,
+    gitref::AbstractString,
     version::VersionNumber,
     commit::AbstractString,
     patch_notes::AbstractString,
@@ -25,7 +25,7 @@ function pull_request_contents(;
         "- Registering package: $package",
         "- Repository: $repo",
         "- Created by: $user",
-        "- Branch: $branch",
+        "- Git reference: $gitref",
         "- Version: v$version",
         "- Commit: $commit",
     ]

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -451,7 +451,7 @@ errors or warnings that occurred.
 function register(
     package_repo::AbstractString, pkg::Pkg.Types.Project, tree_hash::AbstractString;
     registry::AbstractString = DEFAULT_REGISTRY_URL,
-    registry_deps::Vector{<:AbstractString} = String[],
+    registry_deps::Vector{<:AbstractString} = [],
     push::Bool = false,
     gitconfig::Dict = Dict()
 )

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -36,7 +36,7 @@ end
 Given a remote repo URL and a git tree spec, get a `Project` object
 for the project file in that tree and a hash string for the tree.
 """
-# function get_project(remote_url::String, tree_spec::String)
+# function get_project(remote_url::AbstractString, tree_spec::AbstractString)
 #     # TODO?: use raw file downloads for GitHub/GitLab
 #     mktempdir(mkpath("packages")) do tmp
 #         # bare clone the package repo
@@ -90,12 +90,12 @@ struct RegBranch
 
     metadata::Dict{String,Any} # "error", "warning", kind etc.
 
-    function RegBranch(pkg::Pkg.Types.Project, branch::String)
+    function RegBranch(pkg::Pkg.Types.Project, branch::AbstractString)
         new(pkg.name, pkg.version, branch, Dict{String,Any}())
     end
 end
 
-function write_registry(registry_path::String, reg::RegistryData)
+function write_registry(registry_path::AbstractString, reg::RegistryData)
     open(registry_path, "w") do io
         TOML.print(io, reg)
     end
@@ -145,10 +145,10 @@ function check_version!(regbr::RegBranch, existing::Vector{VersionNumber}, ver::
     return regbr
 end
 
-findpackageerror(name::String, uuid::Base.UUID, regdata::Array{RegistryData}) =
+findpackageerror(name::AbstractString, uuid::Base.UUID, regdata::Array{RegistryData}) =
     findpackageerror(name, string(uuid), regdata)
 
-function findpackageerror(name::String, u::String, regdata::Array{RegistryData})
+function findpackageerror(name::AbstractString, u::AbstractString, regdata::Array{RegistryData})
     for _registry_data in regdata
         if haskey(_registry_data.packages, u)
             name_in_reg = _registry_data.packages[u]["name"]
@@ -215,7 +215,7 @@ end
 
 import Pkg.Compress.load_versions
 
-function compress(path::String, uncompressed::Dict,
+function compress(path::AbstractString, uncompressed::Dict,
     versions::Vector{VersionNumber} = load_versions(path))
     inverted = Dict()
     for (ver, data) in uncompressed, (key, val) in data
@@ -231,7 +231,7 @@ function compress(path::String, uncompressed::Dict,
     return compressed
 end
 
-function save(path::String, uncompressed::Dict,
+function save(path::AbstractString, uncompressed::Dict,
     versions::Vector{VersionNumber} = load_versions(path))
     compressed = compress(path, uncompressed)
     open(path, write=true) do io
@@ -242,9 +242,9 @@ end
 # ---- End of code copied from Pkg
 
 function find_package_in_registry(pkg::Pkg.Types.Project,
-                                  package_repo::String,
-                                  registry_file::String,
-                                  registry_path::String,
+                                  package_repo::AbstractString,
+                                  registry_file::AbstractString,
+                                  registry_path::AbstractString,
                                   registry_data::RegistryData,
                                   regbr::RegBranch)
     uuid = string(pkg.uuid)
@@ -290,8 +290,8 @@ function find_package_in_registry(pkg::Pkg.Types.Project,
 end
 
 function update_package_file(pkg::Pkg.Types.Project,
-                             package_repo::String,
-                             package_path::String)
+                             package_repo::AbstractString,
+                             package_path::AbstractString)
     package_info = Dict("name" => pkg.name,
                         "uuid" => string(pkg.uuid),
                         "repo" => package_repo)
@@ -304,9 +304,9 @@ function update_package_file(pkg::Pkg.Types.Project,
 end
 
 function update_versions_file(pkg::Pkg.Types.Project,
-                              package_path::String,
+                              package_path::AbstractString,
                               regbr::RegBranch,
-                              tree_hash::String)
+                              tree_hash::AbstractString)
     versions_file = joinpath(package_path, "Versions.toml")
     versions_data = isfile(versions_file) ? TOML.parsefile(versions_file) : Dict()
     versions = sort!([VersionNumber(v) for v in keys(versions_data)])
@@ -326,7 +326,7 @@ function update_versions_file(pkg::Pkg.Types.Project,
 end
 
 function update_deps_file(pkg::Pkg.Types.Project,
-                          package_path::String,
+                          package_path::AbstractString,
                           regbr::RegBranch,
                           regdata::Vector{RegistryData})
     if pkg.name in keys(pkg.deps)
@@ -359,7 +359,7 @@ function update_deps_file(pkg::Pkg.Types.Project,
 end
 
 function update_compat_file(pkg::Pkg.Types.Project,
-                            package_path::String,
+                            package_path::AbstractString,
                             regbr::RegBranch,
                             regdata::Vector{RegistryData},
                             regpaths::Vector{String})
@@ -470,13 +470,13 @@ errors or warnings that occurred.
 
 # Arguments
 
-* `package_repo::String`: the git repository URL for the package to be registered
+* `package_repo::AbstractString`: the git repository URL for the package to be registered
 * `pkg::Pkg.Types.Project`: the parsed Project.toml file for the package to be registered
-* `tree_hash::String`: the tree hash (not commit hash) of the package revision to be registered
+* `tree_hash::AbstractString`: the tree hash (not commit hash) of the package revision to be registered
 
 # Keyword Arguments
 
-* `registry::String="$DEFAULT_REGISTRY_URL"`: the git repository URL for the registry
+* `registry::AbstractString="$DEFAULT_REGISTRY_URL"`: the git repository URL for the registry
 * `registry_deps::Vector{String}=[]`: the git repository URLs for any registries containing
     packages depended on by `pkg`
 * `push::Bool=false`: whether to push a registration branch to `registry` for consideration
@@ -484,7 +484,7 @@ errors or warnings that occurred.
 """
 function register(
     package_repo::AbstractString, pkg::Pkg.Types.Project, tree_hash::AbstractString;
-    registry::String = DEFAULT_REGISTRY_URL,
+    registry::AbstractString = DEFAULT_REGISTRY_URL,
     registry_deps::Vector{<:AbstractString} = String[],
     push::Bool = false,
     gitconfig::Dict = Dict()
@@ -550,7 +550,7 @@ function register(
         @debug("check compat section")
         regpaths = [registry_path; registry_deps_paths]
         r = update_compat_file(pkg, package_path, regbr, regdata, regpaths)
-        r === nothing || return r 
+        r === nothing || return r
 
         regtreesha = get_registrator_tree_sha()
 

--- a/src/regedit/types.jl
+++ b/src/regedit/types.jl
@@ -28,7 +28,7 @@ Return a `GitRepo` object for an up-to-date copy of `registry`.
 Update the existing copy if available.
 """
 function get_registry(
-    registry_url::String;
+    registry_url::AbstractString;
     gitconfig::Dict=Dict(),
     cache::RegistryCache=REGISTRY_CACHE,
 )

--- a/test/webui.jl
+++ b/test/webui.jl
@@ -7,162 +7,175 @@ using Sockets: Sockets
 
 const UI = Registrator.WebUI
 
-const config = Dict(
-    "GITHUB_API_TOKEN" => get(ENV, "GITHUB_API_TOKEN", "abc"),
-    "GITHUB_CLIENT_ID" => "abc",
-    "GITHUB_CLIENT_SECRET" => "abc",
-    "GITLAB_API_TOKEN" => "abc",
-    "GITLAB_CLIENT_ID" => "abc",
-    "GITLAB_CLIENT_SECRET" => "abc",
-    "REGISTRY_URL" => "https://github.com/JuliaRegistries/General",
-    "SERVER_URL" => "http://localhost:4000",
-    "REGISTRY_CLONE_URL" => nothing,
-)
+empty!(UI.CONFIG)
+merge!(UI.CONFIG, Dict(
+    "ip" => "localhost",
+    "port" => 4000,
+    "registry_url" => "https://github.com/JuliaRegistries/General",
+    "server_url" => "http://localhost:4000",
+    "github" => Dict{String, Any}(
+        # We need a token to avoid rate limits on Travis.
+        "token" => get(ENV, "GITHUB_API_TOKEN", ""),
+        "client_id" => "",
+        "client_secret" => "",
+    ),
+    "gitlab" => Dict{String, Any}(
+        "token" => "",
+        "client_id" => "",
+        "client_secret" => "",
+    ),
+))
+
+const backup = deepcopy(UI.CONFIG)
+
+function restoreconfig!()
+    empty!(UI.CONFIG)
+    merge!(UI.CONFIG, deepcopy(backup))
+end
 
 @testset "Web UI" begin
-    withenv(config...) do
-        @testset "Provider initialization" begin
-            UI.init_providers()
-            @test length(UI.PROVIDERS) == 2
-            @test Set(collect(keys(UI.PROVIDERS))) == Set(["github", "gitlab"])
-            empty!(UI.PROVIDERS)
-
-            withenv("DISABLED_PROVIDERS" => "github", "GITLAB_DISABLE_RATE_LIMITS" => "true") do
-                UI.init_providers()
-                @test collect(keys(UI.PROVIDERS)) == ["gitlab"]
-                @test !GitForge.has_rate_limits(UI.PROVIDERS["gitlab"].client, identity)
-                empty!(UI.PROVIDERS)
-            end
-
-            mktemp() do path, io
-                extra_provider = """
-                    PROVIDERS["myprovider"] = Provider(;
-                        name="MyProvider",
-                        client=GitHubAPI(),
-                        client_id="abc",
-                        client_secret="abc",
-                        auth_url="abc",
-                        token_url="abc",
-                        scope="public_repo",
-                    )
-                    """
-                print(io, extra_provider)
-                close(io)
-
-                withenv("EXTRA_PROVIDERS" => path) do
-                    UI.init_providers()
-                    @test haskey(UI.PROVIDERS, "myprovider")
-                    empty!(UI.PROVIDERS)
-                end
-            end
-        end
-
-        # Patch the GitHub API client to avoid needing a real API key.
-        t = ENV["GITHUB_API_TOKEN"] == "abc" ? NoToken() : Token(ENV["GITHUB_API_TOKEN"])
+    @testset "Provider initialization" begin
         UI.init_providers()
-        UI.PROVIDERS["github"] = UI.Provider(;
-            name="GitHub",
-            client=GitHubAPI(; token=t),
-            client_id=ENV["GITHUB_CLIENT_ID"],
-            client_secret=ENV["GITHUB_CLIENT_SECRET"],
-            auth_url="https://github.com/login/oauth/authorize",
-            token_url="https://github.com/login/oauth/access_token",
-            scope="public_repo",
-        )
+        @test length(UI.PROVIDERS) == 2
+        @test Set(collect(keys(UI.PROVIDERS))) == Set(["github", "gitlab"])
+        empty!(UI.PROVIDERS)
 
-        @testset "Registry initialization" begin
-            UI.init_registry()
-            reg = UI.REGISTRY[]
-            @test reg.url == reg.clone == ENV["REGISTRY_URL"]
-            @test reg.repo isa GitHub.Repo
+        delete!(UI.CONFIG, "github")
+        UI.CONFIG["gitlab"]["disable_rate_limits"] = true
+        UI.init_providers()
+        @test collect(keys(UI.PROVIDERS)) == ["gitlab"]
+        @test !GitForge.has_rate_limits(UI.PROVIDERS["gitlab"].client, identity)
+        empty!(UI.PROVIDERS)
+        restoreconfig!()
 
-            withenv("REGISTRY_CLONE_URL" => "git@github.com:JuliaRegistries/General.git") do
-                UI.init_registry()
-                reg = UI.REGISTRY[]
-                @test reg.url == ENV["REGISTRY_URL"]
-                @test reg.clone == ENV["REGISTRY_CLONE_URL"]
-            end
+        mktemp() do path, io
+            extra_provider = """
+                PROVIDERS["myprovider"] = Provider(;
+                    name="MyProvider",
+                    client=GitHubAPI(),
+                    client_id="abc",
+                    client_secret="abc",
+                    auth_url="abc",
+                    token_url="abc",
+                    scope="public_repo",
+                )
+                """
+            print(io, extra_provider)
+            close(io)
+
+            UI.CONFIG["extra_providers"] = path
+            UI.init_providers()
+            @test haskey(UI.PROVIDERS, "myprovider")
+            empty!(UI.PROVIDERS)
+            restoreconfig!()
         end
+    end
 
-        # Start the server.
-        # TODO: Stop it when this test set is done.
-        task = UI.start_server(Sockets.localhost, 4000)
+    # Patch the GitHub API client to avoid needing a real API key.
+    t = isempty(UI.CONFIG["github"]["token"]) ? NoToken() : Token(UI.CONFIG["github"]["token"])
+    UI.init_providers()
+    UI.PROVIDERS["github"] = UI.Provider(;
+        name="GitHub",
+        client=GitHubAPI(; token=t),
+        client_id=UI.CONFIG["github"]["client_id"],
+        client_secret=UI.CONFIG["github"]["client_secret"],
+        auth_url="https://github.com/login/oauth/authorize",
+        token_url="https://github.com/login/oauth/access_token",
+        scope="public_repo",
+    )
 
-        @testset "404s" begin
-            rs = [UI.ROUTE_INDEX, UI.ROUTE_AUTH, UI.ROUTE_CALLBACK, UI.ROUTE_SELECT, UI.ROUTE_REGISTER]
-            for r in rs
-                resp = HTTP.get(ENV["SERVER_URL"] * r * "/foo"; status_exception=false)
-                @test resp.status == 404
-                @test occursin("Page not found", String(resp.body))
-            end
+    @testset "Registry initialization" begin
+        UI.init_registry()
+        reg = UI.REGISTRY[]
+        @test reg.url == reg.clone == UI.CONFIG["registry_url"]
+        @test reg.repo isa GitHub.Repo
+
+        UI.CONFIG["registry_clone_url"] = "git@github.com:JuliaRegistries/General.git"
+        UI.init_registry()
+        reg = UI.REGISTRY[]
+        @test reg.url == UI.CONFIG["registry_url"]
+        @test reg.clone == UI.CONFIG["registry_clone_url"]
+        restoreconfig!()
+    end
+
+    # Start the server.
+    # TODO: Stop it when this test set is done.
+    task = UI.start_server(Sockets.localhost, 4000)
+
+    @testset "404s" begin
+        rs = [UI.ROUTE_INDEX, UI.ROUTE_AUTH, UI.ROUTE_CALLBACK, UI.ROUTE_SELECT, UI.ROUTE_REGISTER]
+        for r in rs
+            resp = HTTP.get(UI.CONFIG["server_url"] * r * "/foo"; status_exception=false)
+            @test resp.status == 404
+            @test occursin("Page not found", String(resp.body))
         end
+    end
 
-        @testset "Route: /" begin
-            # The response should contain the registry URL and authentication links.
-            resp = HTTP.get(ENV["SERVER_URL"]; status_exception=false)
-            @test resp.status == 200
-            s = String(resp.body)
-            @test occursin(ENV["REGISTRY_URL"], s)
-            @test occursin("GitHub", s)
-            @test occursin("GitLab", s)
+    @testset "Route: /" begin
+        # The response should contain the registry URL and authentication links.
+        resp = HTTP.get(UI.CONFIG["server_url"]; status_exception=false)
+        @test resp.status == 200
+        s = String(resp.body)
+        @test occursin(UI.CONFIG["registry_url"], s)
+        @test occursin("GitHub", s)
+        @test occursin("GitLab", s)
 
-            # When a provider is disabled, its authentication link should not appear.
-            delete!(UI.PROVIDERS, "gitlab")
-            resp = HTTP.get(ENV["SERVER_URL"]; status_exception=false)
-            @test resp.status == 200
-            s = String(resp.body)
-            @test occursin("GitHub", s)
-            @test !occursin("GitLab", s)
-        end
+        # When a provider is disabled, its authentication link should not appear.
+        delete!(UI.PROVIDERS, "gitlab")
+        resp = HTTP.get(UI.CONFIG["server_url"]; status_exception=false)
+        @test resp.status == 200
+        s = String(resp.body)
+        @test occursin("GitHub", s)
+        @test !occursin("GitLab", s)
+    end
 
-        @testset "Route: /select" begin
-            resp = HTTP.get(ENV["SERVER_URL"] * UI.ROUTE_SELECT; status_exception=false)
-            @test resp.status == 200
-            @test occursin("package to register", String(resp.body))
-        end
+    @testset "Route: /select" begin
+        resp = HTTP.get(UI.CONFIG["server_url"] * UI.ROUTE_SELECT; status_exception=false)
+        @test resp.status == 200
+        @test occursin("package to register", String(resp.body))
+    end
 
-        @testset "Route: /register (validation)" begin
-            resp = HTTP.get(ENV["SERVER_URL"] * UI.ROUTE_REGISTER; status_exception=false)
-            @test resp.status == 405
-            @test occursin("Method not allowed", String(resp.body))
+    @testset "Route: /register (validation)" begin
+        resp = HTTP.get(UI.CONFIG["server_url"] * UI.ROUTE_REGISTER; status_exception=false)
+        @test resp.status == 405
+        @test occursin("Method not allowed", String(resp.body))
 
-            resp = HTTP.post(ENV["SERVER_URL"] * UI.ROUTE_REGISTER; status_exception=false)
-            @test resp.status == 400
-            @test occursin("Missing or invalid state cookie", String(resp.body))
+        resp = HTTP.post(UI.CONFIG["server_url"] * UI.ROUTE_REGISTER; status_exception=false)
+        @test resp.status == 400
+        @test occursin("Missing or invalid state cookie", String(resp.body))
 
-            # Pretend we've gone through authentication.
-            state = "foo"
-            client = UI.PROVIDERS["github"].client
-            user = @gf get_user(client, "christopher-dG")
-            UI.USERS[state] = UI.User(user, client)
+        # Pretend we've gone through authentication.
+        state = "foo"
+        client = UI.PROVIDERS["github"].client
+        user = @gf get_user(client, "christopher-dG")
+        UI.USERS[state] = UI.User(user, client)
 
-            url = ENV["SERVER_URL"] * UI.ROUTE_REGISTER
-            cookies = Dict("state" => state)
+        url = UI.CONFIG["server_url"] * UI.ROUTE_REGISTER
+        cookies = Dict("state" => state)
 
-            body = "package=&ref=master"
-            resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
-            @test resp.status == 400
-            @test occursin("Package URL was not provided", String(resp.body))
+        body = "package=&ref=master"
+        resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
+        @test resp.status == 400
+        @test occursin("Package URL was not provided", String(resp.body))
 
-            body = "package=foo&ref=master"
-            resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
-            @test resp.status == 400
-            @test occursin("Package URL is invalid", String(resp.body))
+        body = "package=foo&ref=master"
+        resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
+        @test resp.status == 400
+        @test occursin("Package URL is invalid", String(resp.body))
 
-            body = "package=https://github.com/foo/bar&ref="
-            resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
-            @test resp.status == 400
-            @test occursin("Branch was not provided", String(resp.body))
+        body = "package=https://github.com/foo/bar&ref="
+        resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
+        @test resp.status == 400
+        @test occursin("Branch was not provided", String(resp.body))
 
-            body = "package=https://github.com/JuliaLang/NotARealRepo&ref=master"
-            resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
-            @test resp.status == 400
-            @test occursin("Repository was not found", String(resp.body))
+        body = "package=https://github.com/JuliaLang/NotARealRepo&ref=master"
+        resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
+        @test resp.status == 400
+        @test occursin("Repository was not found", String(resp.body))
 
-            body = "package=http://github.com/JuliaLang/julia&ref=master"
-            resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
-            @test resp.status == 400
-            @test occursin("Unauthorized to release this package", String(resp.body))
-        end
+        body = "package=http://github.com/JuliaLang/julia&ref=master"
+        resp = HTTP.post(url; body=body, cookies=cookies, status_exception=false)
+        @test resp.status == 400
+        @test occursin("Unauthorized to release this package", String(resp.body))
     end
 end


### PR DESCRIPTION
On top of #149, only commits including and after f98019571ffa024f10f46bdb5174fd25b1981884 are new.

This gives the web UI its own configuration file, without touching the existing GItHub bot's file.

Kind of WIP but as far as I can tell it's working identically to before.