### PR TITLE
Don't include git ref in PRs from GitHub app

### DIFF
--- a/src/Server.jl
+++ b/src/Server.jl
@@ -761,7 +761,6 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         package=name,
         repo=string(rp.evt.repository.html_url),
         user="@$creator",
-        gitref=brn,
         version=ver,
         commit=pp.sha,
         patch_notes=rp.patch_notes,

--- a/src/pull_request.jl
+++ b/src/pull_request.jl
@@ -6,10 +6,10 @@ function pull_request_contents(;
     package::AbstractString,
     repo::AbstractString,
     user::AbstractString,
-    gitref::AbstractString,
     version::VersionNumber,
     commit::AbstractString,
     patch_notes::AbstractString,
+    gitref::AbstractString="",
     reviewer::AbstractString="",
     reference::AbstractString="",
     meta::AbstractString="",
@@ -25,11 +25,11 @@ function pull_request_contents(;
         "- Registering package: $package",
         "- Repository: $repo",
         "- Created by: $user",
-        "- Git reference: $gitref",
         "- Version: v$version",
         "- Commit: $commit",
     ]
 
+    isempty(gitref) || push!(lines, "- Git reference: $gitref")
     isempty(reviewer) || push!(lines, "- Reviewed by: $reviewer")
     isempty(reference) || push!(lines, "- Reference: $reference")
     isempty(patch_notes) || push!(


### PR DESCRIPTION
I thought this was going to be the branch of the package repo being released, but it's not. It's not necessary anyways. 