### PR TITLE
Make patch notes capture case-insensitive

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -55,9 +55,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[GitForge]]
 deps = ["Dates", "HTTP", "JSON2"]
-git-tree-sha1 = "5f76d938f3f5e2665b234854cd7303124c5f6634"
+git-tree-sha1 = "8d7dbd341b92fa2a8140dd3f06484bbb57f91623"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
-version = "0.1.1"
+version = "0.1.2"
 
 [[GitHub]]
 deps = ["Base64", "Compat", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "Test"]
@@ -94,12 +94,10 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.20.0"
 
 [[JSON2]]
-deps = ["Dates", "Parsers"]
-git-tree-sha1 = "36180793e9b043af9d07966482eb3a16f903649f"
-repo-rev = "cdg/options"
-repo-url = "https://github.com/christopher-dG/JSON2.jl"
+deps = ["Dates", "Parsers", "Test"]
+git-tree-sha1 = "6cbbbab27d9411946725f5d5c91e8b8fb5f7d5db"
 uuid = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3"
-version = "0.3.0"
+version = "0.3.1"
 
 [[Lazy]]
 deps = ["Compat", "MacroTools", "Test"]

--- a/README.md
+++ b/README.md
@@ -43,19 +43,20 @@ Either:
 
 If you want to register as a private member you should host your own instance of Registrator, see [docs.md](https://github.com/JuliaRegistries/Registrator.jl/blob/master/docs.md)
 
-### Patch notes
+### Release notes
 
-If you have enabled TagBot for your repositories, then you have the option to write your patch notes in the same place that you trigger Registrator.
+If you have enabled TagBot for your repositories, then you have the option to write your release notes in the same place that you trigger Registrator.
 The notes will be copied into your GitHub release.
-To do this, add a section labeled "Patch notes:" to your Registrator trigger issue/comment.
+To do this, add a section labeled "Release notes:" to your Registrator trigger issue/comment.
 This must occur at the end of the trigger.
+The phrase "Patch notes:" is also supported.
 
 Example:
 
 ```
 @JuliaRegistrator register()
 
-Patch notes:
+Release notes:
 
 Check out my new features!
 ```

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -87,7 +87,7 @@ struct RequestParams{T<:RequestTrigger}
                 # TODO:
                 # - The syntax with which users declare their patch notes is still undecided.
                 # - This assumes that patch notes appear last in the body. Is that fair?
-                patch_match = match(r"Patch notes:(.*)"s, get_body(evt.payload))
+                patch_match = match(r"Patch notes:(.*)"si, get_body(evt.payload))
                 patch_notes = patch_match === nothing ? "" : strip(patch_match[1])
                 if is_pull_request(evt.payload)
                     if config["registrator"]["disable_pull_request_trigger"]

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -87,7 +87,7 @@ struct RequestParams{T<:RequestTrigger}
                 # TODO:
                 # - The syntax with which users declare their patch notes is still undecided.
                 # - This assumes that patch notes appear last in the body. Is that fair?
-                patch_match = match(r"Patch notes:(.*)"si, get_body(evt.payload))
+                patch_match = match(r"(?:patch|release) notes:(.*)"si, get_body(evt.payload))
                 patch_notes = patch_match === nothing ? "" : strip(patch_match[1])
                 if is_pull_request(evt.payload)
                     if config["registrator"]["disable_pull_request_trigger"]


### PR DESCRIPTION
I'd expect plenty of people to use "Patch Notes:", etc.