### PR TITLE
Update comment trigger to not need to be Julia syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,20 @@ Registrator is a GitHub app that automates creation of registration pull request
 First, install the app on your package(s) as mentioned above.  The procedure for registering a new package is the same as for releasing a new version.
 
 1. Set the [Project.toml](Project.toml) version field in your repository to your new desired `version`.
-2. Comment `@JuliaRegistrator register()` on the commit/branch you want to register (e.g. like [here](https://github.com/JuliaRegistries/Registrator.jl/issues/61#issuecomment-483486641) or [here](https://github.com/chakravala/Grassmann.jl/commit/3c3a92610ebc8885619f561fe988b0d985852fce#commitcomment-33233149)).
+2. Comment `@JuliaRegistrator register` on the commit/branch you want to register (e.g. like [here](https://github.com/JuliaRegistries/Registrator.jl/issues/61#issuecomment-483486641) or [here](https://github.com/chakravala/Grassmann.jl/commit/3c3a92610ebc8885619f561fe988b0d985852fce#commitcomment-33233149)).
 3. If something is incorrect, adjust, and redo step 2.
 4. Finally, either rely on [TagBot](https://github.com/apps/julia-tagbot) to tag and make a github release or alternatively tag the release manually.
 
 Registrator will look for the project file in the master branch by default, and will use the version set in the Project.toml file via, for example, `version = "0.1.0"`. To use a custom branch comment with:
 
 ```
-@JuliaRegistrator register(branch="name-of-your-branch")
+@JuliaRegistrator register branch=name-of-your-branch
+```
+
+The old pseudo-Julia syntax is also still supported:
+
+```
+@JuliaRegistrator register(branch="foo")
 ```
 
 ### Transitioning from REQUIRE to Project.toml
@@ -36,8 +42,8 @@ Check that your package conforms to the required `Project.toml` structure found 
 
 Either:
 
-1. Open an issue and add ` @JuliaRegistrator register() ` as a comment.  You can re-trigger the registrator by commenting ` @JuliaRegistrator register() ` again (in case registrator reports an error or to make changes).
-2. Add a comment to a commit and say ` @JuliaRegistrator register() `.
+1. Open an issue and add ` @JuliaRegistrator register` as a comment.  You can re-trigger the registrator by commenting ` @JuliaRegistrator register` again (in case registrator reports an error or to make changes).
+2. Add a comment to a commit and say ` @JuliaRegistrator register`.
 
 *Note*: Only *collaborators* on the package repository and *public members* on the organization the package is under are allowed to register. If you are not a collaborator, you can request a collaborator trigger registrator in a GitHub issue or a comment on a commit.
 
@@ -50,7 +56,7 @@ These can later be edited via the GitHub releases interface.
 
 To write your release notes, add a section labeled "Release notes:" or "Patch notes:" to your Registrator trigger issue/comment, after the `@JuliaRegistrator` trigger. For example,
 ```
-@JuliaRegistrator register()
+@JuliaRegistrator register
 
 Release notes:
 

--- a/run/config.commentbot.toml
+++ b/run/config.commentbot.toml
@@ -5,8 +5,8 @@ http_ip = "0.0.0.0"
 log_level = "debug"
 backend_port = 5555             # Port of the backend regservice
 
-trigger = "JuliaRegistrator"    # The comment that should trigger Registrator. Typically
-                                # keep this the same as your GitHub user
+trigger = "@JuliaRegistrator"   # The comment that should trigger Registrator. Typically
+                                # keep this the same as your GitHub user mention.
 
 stop_file = "/tmp/stopcommentbot" # `touch` this file to stop the comment bot
 

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -206,7 +206,7 @@ end
 function github_webhook(http_ip=config["http_ip"],
                         http_port=get(config, "http_port", parse(Int, get(ENV, "PORT", "8001"))))
     auth = get_jwt_auth()
-    trigger = Regex("@$(config["trigger"]) $accept_regex")
+    trigger = Regex(config["trigger"] * "(.*)")
     listener = GitHub.CommentListener(comment_handler, trigger; check_collab=false, auth=auth, secret=config["github"]["secret"])
     httpsock[] = Sockets.listen(IPv4(http_ip), http_port)
 

--- a/src/commentbot/param_types.jl
+++ b/src/commentbot/param_types.jl
@@ -23,7 +23,7 @@ struct RequestParams{T<:RequestTrigger}
         err = nothing
         report_error = false
 
-        text = strip(strip(phrase[1], ['`']))
+        text = strip(phrase[1], [' ', '`'])
         action_name, action_kwargs = parse_comment(text)
         if action_name === nothing
             return new{typeof(trigger_src)}(

--- a/src/commentbot/param_types.jl
+++ b/src/commentbot/param_types.jl
@@ -23,8 +23,17 @@ struct RequestParams{T<:RequestTrigger}
         err = nothing
         report_error = false
 
-        command = strip(phrase.captures[1], [' ', '`'])
-        action_name, action_args, action_kwargs = parse_comment(command)
+        text = strip(strip(phrase[1], ['`']))
+        action_name, action_kwargs = parse_comment(text)
+        if action_name === nothing
+            return new{typeof(trigger_src)}(
+                evt, phrase, reponame, notes, trigger_src,
+                commenter_can_register, nothing,
+                CommonParams(false, "Invalid trigger, ignoring", report_error),
+            )
+        end
+
+        branch = get(action_kwargs, :branch, "master")
         target = get(action_kwargs, :target, nothing)
 
         if evt.payload["repository"]["private"] && get(config, "disable_private_registrations", true)
@@ -49,9 +58,8 @@ struct RequestParams{T<:RequestTrigger}
                     trigger_src = CommitCommentTrigger()
                 else
                     @debug("Comment is on an issue")
-                    brn = get(action_kwargs, :branch, "master")
-                    @debug("Will use branch", brn)
-                    trigger_src = IssueTrigger(brn)
+                    @debug("Will use branch", branch)
+                    trigger_src = IssueTrigger(branch)
                 end
             else
                 err = register_rights_error(evt, user)

--- a/src/commentbot/parse_comment.jl
+++ b/src/commentbot/parse_comment.jl
@@ -27,7 +27,7 @@ function parse_comment(text::AbstractString)
     end
 
     # The first capture is the action.
-    action = captures[1]
+    action = string(captures[1])
 
     # The second capture is keyword arguments.
     kwargs = Dict{Symbol, String}()

--- a/src/commentbot/parse_comment.jl
+++ b/src/commentbot/parse_comment.jl
@@ -15,7 +15,6 @@ Valid input would look like this:
 
 The old syntax `action(key1=val1)` is supported for backwards compatibility.
 """
-
 function parse_comment(text::AbstractString)
     # Handling leading ( is easy, but not capturing the closing one is a bit harder.
     text = strip(rstrip(text, ')'))

--- a/src/commentbot/parse_comment.jl
+++ b/src/commentbot/parse_comment.jl
@@ -1,26 +1,48 @@
-const accept_regex = "([^\\r\\n]*)(\\n|\\r)*.*"
+"""
+    parse_comment(text::AbstractString) -> (String, Dict{Symbol, String})
 
-function parse_comment(fncall)
-    argind = findfirst(isequal('('), fncall)
-    name = fncall[1:(argind - 1)]
-    parsed_args = Meta.parse(replace(fncall[argind:end], ";" => ","))
-    args, kwargs = Vector{String}(), Dict{Symbol,String}()
-    if isa(parsed_args, Expr) && parsed_args.head == :tuple
-        started_kwargs = false
-        for x in parsed_args.args
-            if isa(x, Expr) && (x.head == :kw || x.head == :(=)) && isa(x.args[1], Symbol)
-                @assert !haskey(kwargs, x.args[1]) "kwargs must all be unique"
-                kwargs[x.args[1]] = string(x.args[2])
-                started_kwargs = true
-            else
-                @assert !started_kwargs "kwargs must come after other args"
-                push!(args, string(x))
-            end
-        end
-    elseif isa(parsed_args, Expr) && parsed_args.head == :(=) && isa(parsed_args.args[1], Symbol)
-        kwargs[parsed_args.args[1]] = string(parsed_args.args[2])
-    else
-        push!(args, string(parsed_args))
+Parse a trigger comment with keyword arguments, and return (`name`, `keywords`).
+Positional arguments are ignored.
+
+If the input is invalid `(nothing, nothing)` is returned.
+
+Valid input would look like this:
+
+```
+<action> key1=val1 key2=val2
+--- anything here and below ---
+```
+
+The old syntax `action(key1=val1)` is supported for backwards compatibility.
+"""
+
+function parse_comment(text::AbstractString)
+    # Handling leading ( is easy, but not capturing the closing one is a bit harder.
+    text = strip(rstrip(text, ')'))
+
+    captures = match(r"(\w+)\(?\s*(.*)", text)
+    if captures === nothing
+        @debug "Invalid trigger" text
+        return nothing, nothing
     end
-    return name, args, kwargs
+
+    # The first capture is the action.
+    action = captures[1]
+
+    # The second capture is keyword arguments.
+    kwargs = Dict{Symbol, String}()
+    foreach(eachmatch(r"([a-zA-Z_]\w*)\s*=\s*([^\s,]+)", captures[2])) do c
+        # If the value is a literal string, remove the quotes.
+        key = Symbol(c[1])
+        val = strip(c[2], [' ', '"'])
+        kwargs[key] = val
+    end
+
+    # Check that there are no duplicates or other oddities.
+    if length(kwargs) != count(isequal('='), captures[2])
+        @debug "Invalid trigger arguments" text args=captures[2]
+        return nothing, nothing
+    end
+
+    return action, kwargs
 end

--- a/test/server.jl
+++ b/test/server.jl
@@ -4,29 +4,22 @@ using Test
 
 @testset "Server" begin
 
-@testset "accept_regex" begin
-    r = Regex("@JuliaRegistrator $accept_regex")
-    @test match(r, "@JuliaRegistrator register()")[1] == "register()"
-    @test match(r, "@JuliaRegistrator register()\r\n\r\n")[1] == "register()"
-    @test match(r, """@JuliaRegistrator register()
-                Patch notes:
-                Release v0.1.0
-                Fixes bugs
-                """)[1] == "register()"
-end
-
 @testset "parse_comment" begin
-    @test parse_comment("register()") == ("register", [], Dict{Symbol,String}())
-    @test parse_comment("register(qux)") == ("register", ["qux"], Dict{Symbol,String}())
-    @test parse_comment("register(qux, baz)") == ("register", ["qux", "baz"], Dict{Symbol,String}())
+    @test parse_comment("register()") == ("register", Dict{Symbol,String}())
+    @test parse_comment("approved()") == ("approved", Dict{Symbol,String}())
 
-    @test parse_comment("approved()") == ("approved", [], Dict{Symbol,String}())
+    @test parse_comment("register(target=qux)") == ("register", Dict(:target=>"qux"))
+    @test parse_comment("register(target=qux, branch=baz)") == ("register", Dict(:branch=>"baz",:target=>"qux"))
+    @test parse_comment("register(target=foo, branch=bar)") == ("register", Dict(:branch=>"bar",:target=>"foo"))
 
-    @test parse_comment("register(target=qux)") == ("register", String[], Dict(:target=>"qux"))
-    @test parse_comment("register(target=qux, branch=baz)") == ("register", String[], Dict(:branch=>"baz",:target=>"qux"))
-    @test parse_comment("register(qux, baz, target=foo, branch=bar)") == ("register", ["qux", "baz"], Dict(:branch=>"bar",:target=>"foo"))
+    @test parse_comment("register(branch=\"release-1.0\")") == ("register", Dict(:branch=>"release-1.0"))
 
-    @test parse_comment("register(branch=\"release-1.0\")") == ("register", String[], Dict(:branch=>"release-1.0"))
+    @test parse_comment("register") == ("register", Dict{Symbol, String}())
+    @test parse_comment("register branch=foo target=bar") == ("register", Dict(:branch => "foo", :target => "bar"))
+    @test parse_comment("register branch = foo target = bar") == ("register", Dict(:branch => "foo", :target => "bar"))
+    @test parse_comment("register branch=foo, target=bar") == ("register", Dict(:branch => "foo", :target => "bar"))
+
+    @test parse_comment("register branch=foo branch=bar") == (nothing, nothing)
 end
 
 end


### PR DESCRIPTION
Relevant: #130

This removes the usage of the Julia parser, adds a modified new syntax for commands, but keeps the old one intact.

Example:

```
@JuliaRegistrator register branch=release-1.0 target=myregistry
```

The only thing lost is the capture of positional arguments in the psuedo-function-call, which we never used anyways.