### PR TITLE
Properly strip parens for multi-line input

### DIFF
--- a/src/commentbot/parse_comment.jl
+++ b/src/commentbot/parse_comment.jl
@@ -17,7 +17,8 @@ The old syntax `action(key1=val1)` is supported for backwards compatibility.
 """
 function parse_comment(text::AbstractString)
     # Handling leading ( is easy, but not capturing the closing one is a bit harder.
-    text = join(map(line -> rstrip(line, [' ', ')']), split(text, "\n")), "\n")
+    lines = eachline(IOBuffer(text))
+    text = join(map(line -> rstrip(line, [' ', ')']), lines), "\n")
 
     captures = match(r"(\w+)\(?\s*(.*)", text)
     if captures === nothing

--- a/src/commentbot/parse_comment.jl
+++ b/src/commentbot/parse_comment.jl
@@ -17,8 +17,7 @@ The old syntax `action(key1=val1)` is supported for backwards compatibility.
 """
 function parse_comment(text::AbstractString)
     # Handling leading ( is easy, but not capturing the closing one is a bit harder.
-    lines = eachline(IOBuffer(text))
-    text = join(map(line -> rstrip(line, [' ', ')']), lines), "\n")
+    text = replace(text, r"[\)\s]+$"m => "")
 
     captures = match(r"(\w+)\(?\s*(.*)", text)
     if captures === nothing

--- a/src/commentbot/parse_comment.jl
+++ b/src/commentbot/parse_comment.jl
@@ -17,7 +17,7 @@ The old syntax `action(key1=val1)` is supported for backwards compatibility.
 """
 function parse_comment(text::AbstractString)
     # Handling leading ( is easy, but not capturing the closing one is a bit harder.
-    text = strip(rstrip(text, ')'))
+    text = join(map(line -> rstrip(line, [' ', ')']), split(text, "\n")), "\n")
 
     captures = match(r"(\w+)\(?\s*(.*)", text)
     if captures === nothing

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,4 +1,4 @@
-import Registrator.CommentBot: accept_regex, parse_comment
+import Registrator.CommentBot: parse_comment
 
 using Test
 
@@ -18,6 +18,8 @@ using Test
     @test parse_comment("register branch=foo target=bar") == ("register", Dict(:branch => "foo", :target => "bar"))
     @test parse_comment("register branch = foo target = bar") == ("register", Dict(:branch => "foo", :target => "bar"))
     @test parse_comment("register branch=foo, target=bar") == ("register", Dict(:branch => "foo", :target => "bar"))
+
+    @test parse_comment("register(branch=foo)\nfoobar\"") == ("register", Dict(:branch => "foo"))
 
     @test parse_comment("register branch=foo branch=bar") == (nothing, nothing)
 end


### PR DESCRIPTION
Previously something like this:

```
register(branch="foo")
Some other text
```

Would parse `:branch => "foo)"`.

This is actually a non-issue for the current deploy because the input to the function never contains more than one line, but it's better to not make that assumption.