### PR TITLE
WebUI: Use long polling for registration status check

### DIFF
--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -1,5 +1,4 @@
 # Step 5: Register the package (maybe).
-# TODO: Use a register queue and call RegService
 function register(r::HTTP.Request)
     r.method == "POST" || return json(405; error="Method not allowed")
 

--- a/src/webui/routes/status.jl
+++ b/src/webui/routes/status.jl
@@ -12,7 +12,7 @@ function status(r::HTTP.Request)
     haskey(REGISTRATIONS, id) || return json(404; state="unknown")
 
     # 10 second arbitrary timeout.
-    for i in 1:10
+    for _ in 1:10
         regstate = REGISTRATIONS[id]
         if regstate.state !== :pending
             delete!(REGISTRATIONS, id)

--- a/src/webui/routes/status.jl
+++ b/src/webui/routes/status.jl
@@ -10,7 +10,16 @@ function status(r::HTTP.Request)
 
     id = getquery(r, "id")
     haskey(REGISTRATIONS, id) || return json(404; state="unknown")
-    regstate = REGISTRATIONS[id]
-    regstate.state === :pending || delete!(REGISTRATIONS, id)
-    return json(; state=regstate.state, message=regstate.msg)
+
+    # 10 second arbitrary timeout.
+    for i in 1:10
+        regstate = REGISTRATIONS[id]
+        if regstate.state !== :pending
+            delete!(REGISTRATIONS, id)
+            return json(; state=regstate.state, message=regstate.msg)
+        end
+        sleep(1)
+    end
+
+    return json(; state="pending", message="Registration in progress...")
 end

--- a/src/webui/templates/select.tpl
+++ b/src/webui/templates/select.tpl
@@ -25,30 +25,25 @@
   function poll_status(id) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', '{{{:route_status}}}?id='+encodeURIComponent(id));
-    xhr.setRequestHeader('Content-Type', 'text/json');
     xhr.onload = function() {
       data = JSON.parse(xhr.responseText);
       div = document.getElementById("reg-form");
 
       var text = ""
       if (xhr.status === 200) {
-        st = data["state"];
+        st = data.state;
         if (st == "success") {
-          console.log("Registration is done");
-          text = data["message"];
+          text = data.message;
         } else if (st == "errored") {
-          console.log("Registration errored");
-          text = "ERROR: " + data["message"];
+          text = "ERROR: " + data.message;
         } else if (st == "pending") {
-          console.log("Registration pending");
-          text = data["message"];
+          text = data.message;
           poll_status(id);
         } else {
-          console.log("Registration unknown state");
           text = "Unknown state returned";
         }
       } else {
-        text = "ERROR: " + data["error"];
+        text = "ERROR: " + data.error;
       }
       div.innerHTML = "<div class='text-center'><h4>" + text + "</h4></div>";
     };
@@ -73,12 +68,10 @@
       div = document.getElementById("reg-form");
 
       if (xhr.status === 200) {
-        console.log("Success sending registration request. Polling for status");
-        div.innerHTML = "<div class='text-center'><h4>" + data["message"] + "</h4></div>";
-        poll_status(data["id"]);
+        div.innerHTML = "<div class='text-center'><h4>" + data.message + "</h4></div>";
+        poll_status(data.id);
       } else {
-        console.log("Error occured while making registration request");
-        div.innerHTML = "<div class='text-center'><h4 class='txt-danger'>ERROR: " + data["error"] + "</h4></div>";
+        div.innerHTML = "<div class='text-center'><h4 class='txt-danger'>ERROR: " + data.error + "</h4></div>";
       }
     };
     xhr.send('package='+encodeURIComponent(package)+'&ref='+ref+'&notes='+encodeURIComponent(notes));

--- a/src/webui/templates/select.tpl
+++ b/src/webui/templates/select.tpl
@@ -42,7 +42,7 @@
         } else if (st == "pending") {
           console.log("Registration pending");
           text = data["message"];
-          setTimeout(function () {poll_status(id);}, 5000);
+          poll_status(id);
         } else {
           console.log("Registration unknown state");
           text = "Unknown state returned";
@@ -50,7 +50,7 @@
       } else {
         text = "ERROR: " + data["error"];
       }
-      div.innerHTML = "<div class='text-center'><h4 class='txt-danger'>" + text + "</h4></div>";
+      div.innerHTML = "<div class='text-center'><h4>" + text + "</h4></div>";
     };
     xhr.send();
   }


### PR DESCRIPTION
This improves the current polling situation a little bit. Instead of sending a request every 5 seconds and instantly getting the current status back, the server waits for up to 10 seconds for the registration to finish. If it's still going, the same process begins again.

This means:

- 5x less requests for the client to make
- Faster response from the server, since checks are effectively every second instead of every 5

The timeout is arbitrary, and could probably be a lot longer.
The next logical step would be websockets but that's less trivial.

A couple of other changes were made, basically just code style. I got rid of the `console.log`s since that's frowned upon. Also the results text was changed from red back to default, I thought it a bit strange to see angry-looking text reporting success.