### PR TITLE
Correctly get tree SHA when ref is a branch

### DIFF
--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -101,7 +101,8 @@ function gettreesha(::GitLabAPI, r::GitLab.Project, ref::AbstractString)
         mktempdir() do dir
             dest = joinpath(dir, r.name)
             run(`git clone $url $dest`)
-            match(r"tree (.*)", readchomp(`git -C $dest show $ref --format=raw`))[1]
+            run(`git -C $dest checkout $ref`)
+            match(r"tree (.*)", readchomp(`git -C $dest show --format=raw`))[1]
         end
     catch ex
         println(get_backtrace(ex))


### PR DESCRIPTION
After cloning a repo, remote branches exist as `origin/branchname` but they do not exist locally. Therefore `git show branchname` always fails unless the branch is `master`.
By running `git checkout branchname`, a local branch is created that tracks the remote one.

Illustrated:

```sh
xps [ ~ ] git clone -q git@github.com:JuliaRegistries/Registrator.jl.git Registrator

# Here's what we were doing before
xps [ ~ ] git -C Registrator show cdg/treesha --format=raw
fatal: ambiguous argument 'cdg/treesha': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

# Here's what we do now 
x xps [ ~ ] git -C Registrator checkout cdg/treesha
Branch 'cdg/treesha' set up to track remote branch 'cdg/treesha' from 'origin'.
Switched to a new branch 'cdg/treesha'
xps [ ~ ] git -C Registrator show --format=raw | grep tree | head -n1
tree cb66e236558566e22ad5609967f364c22c6b1b38
```