### PR TITLE
Ignore whitespace in base64 strings

### DIFF
--- a/src/Registrator.jl
+++ b/src/Registrator.jl
@@ -1,8 +1,11 @@
 module Registrator
 
-using UUIDs, LibGit2
+using Base64
+using LibGit2
+using UUIDs
 
-import Base: PkgId
+# Remove all of a base64 string's whitespace before decoding it.
+decodeb64(s::AbstractString) = String(base64decode(replace(s, r"\s" => "")))
 
 include("slack.jl")
 include("regedit/RegEdit.jl")

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -4,7 +4,6 @@ using Sockets
 using GitHub
 using HTTP
 using Distributed
-using Base64
 using Pkg
 using Logging
 using Dates

--- a/src/commentbot/verify_projectfile.jl
+++ b/src/commentbot/verify_projectfile.jl
@@ -1,3 +1,5 @@
+using ..Registrator: decodeb64
+
 function is_pfile_parseable(c::AbstractString)
     @debug("Checking whether Project.toml is non-empty and parseable")
     if length(c) != 0
@@ -76,7 +78,7 @@ function verify_projectfile_from_sha(reponame, sha; auth=GitHub.AnonymousAuth())
             b = blob(reponame, Blob(tr["sha"]); auth=a)
 
             @debug("Decoding base64 projectfile contents")
-            projectfile_contents = join([String(copy(base64decode(k))) for k in split(b.content)])
+            projectfile_contents = decodeb64(b.content)
 
             @debug("Checking project file validity")
             projectfile_valid, err = is_pfile_valid(projectfile_contents)

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -2,7 +2,6 @@ module WebUI
 
 using ..Registrator: RegEdit, pull_request_contents
 
-using Base64
 using Dates
 using GitForge, GitForge.GitHub, GitForge.GitLab
 using HTTP

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -1,3 +1,5 @@
+using ..Registrator: decodeb64
+
 # # Run some GitForge function, warning on error but still returning the value.
 macro gf(ex::Expr)
     quote
@@ -53,9 +55,6 @@ function isauthorized(u::User{GitLab.User}, repo::GitLab.Project)
     end
     return something(hasauth, false)
 end
-
-# Remove all of a base64 string's whitespace before decoding it.
-decodeb64(s::AbstractString) = String(base64decode(replace(s, r"\s" => "")))
 
 # Get the raw Project.toml text from a repository.
 function gettoml(f::GitHubAPI, repo::GitHub.Repo, ref::AbstractString)

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -54,16 +54,19 @@ function isauthorized(u::User{GitLab.User}, repo::GitLab.Project)
     return something(hasauth, false)
 end
 
+# Remove all of a base64 string's whitespace before decoding it.
+decodeb64(s::AbstractString) = String(base64decode(replace(s, r"\s" => "")))
+
 # Get the raw Project.toml text from a repository.
 function gettoml(f::GitHubAPI, repo::GitHub.Repo, ref::AbstractString)
     fc = @gf get_file_contents(f, repo.owner.login, repo.name, "Project.toml"; ref=ref)
-    return fc === nothing ? nothing : String(base64decode(strip(fc.content)))
+    return fc === nothing ? nothing : decodeb64(fc.content)
 end
 
 function gettoml(::GitLabAPI, repo::GitLab.Project, ref::AbstractString)
     forge = PROVIDERS["gitlab"].client
     fc = @gf get_file_contents(forge, repo.id, "Project.toml"; ref=ref)
-    return fc === nothing ? nothing : String(base64decode(fc.content))
+    return fc === nothing ? nothing : decodeb64(fc.content)
 end
 
 function getcommithash(f::GitHubAPI, repo::GitHub.Repo, ref::AbstractString)

--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -29,7 +29,9 @@ function register(r::HTTP.Request)
     toml === nothing && return json(400; error="Project.toml was not found")
     project = try
         Pkg.Types.read_project(IOBuffer(toml))
-    catch
+    catch e
+        @error "Reading project from Project.toml failed"
+        println(get_backtrace(e))
         return json(400; error="Project.toml is invalid")
     end
     for k in [:name, :uuid, :version]


### PR DESCRIPTION
[Context](https://discourse.julialang.org/t/status-of-registrator-jl-getting-an-invalid-project-toml-error/25546)

The Base64 stdlib does not properly discard whitespace when decoding. This should probably be fixed there too.