### PR TITLE
Include part of the UUID in branch names

### DIFF
--- a/src/regedit/utils.jl
+++ b/src/regedit/utils.jl
@@ -14,4 +14,6 @@ end
 
 Generate the name for the registry branch used to register the package version.
 """
-registration_branch(pkg::Pkg.Types.Project) = "register/$(pkg.name)/v$(pkg.version)"
+function registration_branch(pkg::Pkg.Types.Project)
+    return "registrator/$(lowercase(pkg.name))/$(string(pkg.uuid)[1:8])/v$(pkg.version)"
+end

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -29,16 +29,10 @@ const TEST_SIGNATURE = LibGit2.Signature(
 
     @testset "registration_branch" begin
         example = Project(Dict(
-            "name" => "Example", "version" => "1.10.2"
+            "name" => "Example", "version" => "1.10.2",
+            "uuid" => "698ec630-83b2-4a6d-81d4-a10176273030"
         ))
-
-        @test registration_branch(example) == "register/Example/v1.10.2"
-
-        example = Project(Dict(
-            "name" => "Example", "version" => nothing
-        ))
-
-        @test_throws ArgumentError registration_branch(example)
+        @test registration_branch(example) == "registrator/example/698ec630/v1.10.2"
     end
 end
 


### PR DESCRIPTION
Use `Base.version_slug` for branch names, fixes #165, fixes https://github.com/JuliaRegistries/General/issues/1765.