### PR TITLE
Add pass-through of `cache` for `register()` -> `get_registry()`

### DIFF
--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -475,6 +475,7 @@ function register(
     push::Bool = false,
     force_reset::Bool = true,
     branch::String = registration_branch(pkg),
+    cache::RegistryCache=REGISTRY_CACHE,
     gitconfig::Dict = Dict()
 )
     # get info from package registry
@@ -487,12 +488,12 @@ function register(
     # get up-to-date clone of registry
     @debug("get up-to-date clone of registry")
     registry = GitTools.normalize_url(registry)
-    registry_repo = get_registry(registry; gitconfig=gitconfig, force_reset=force_reset)
+    registry_repo = get_registry(registry; gitconfig=gitconfig, force_reset=force_reset, cache=cache)
     registry_path = LibGit2.path(registry_repo)
 
     isempty(registry_deps) || @debug("get up-to-date clones of registry dependencies")
     registry_deps_paths = map(registry_deps) do registry
-        LibGit2.path(get_registry(GitTools.normalize_url(registry); gitconfig=gitconfig, force_reset=force_reset))
+        LibGit2.path(get_registry(GitTools.normalize_url(registry); gitconfig=gitconfig, force_reset=force_reset, cache=cache))
     end
 
     clean_registry = true

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -436,7 +436,7 @@ function get_registrator_tree_sha()
         regtreesha = reg_pkgs[1].new.hash
     end
     if regtreesha === nothing
-        regpath = abspath(joinpath(pathof(Main.Registrator), "..", ".."))
+        regpath = abspath(joinpath(@__DIR__, "..", ".."))
         if isdir(joinpath(regpath, ".git"))
             regtreesha = LibGit2.head(regpath)
         else


### PR DESCRIPTION
This allows us to register into registries not located in the typical location.