### PR TITLE
ENV Variable configuration of comment bot for Heroku

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -132,8 +132,10 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
     
     # Here we will check if the target registry has a repo argument, and if not,
     # assign it a default one, obtained from ENV.
-    if !haskey(target_registry, "repo") && haskey(ENV, "DEFAULT_REGISTRY_URL")
-        target_registry["repo"] = ENV["DEFAULT_REGISTRY_URL"]
+    if !haskey(target_registry, "repo")
+        specific_env_key = string(uppercase(target_registry_name), "_REGISTRY_URL")
+        envkey = ifelse(haskey(ENV, specific_env_key), specific_env_key, "DEFAULT_REGISTRY_URL")
+        target_registry["repo"] = ENV[envkey]
     end
 
     pp = ProcessedParams(rp)

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -129,6 +129,12 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
             target_registry_name, target_registry = filteredtargets[1]
         end
     end
+    
+    # Here we will check if the target registry has a repo argument, and if not,
+    # assign it a default one, obtained from ENV.
+    if !haskey(target_registry, "repo") && haskey(ENV, "DEFAULT_REGISTRY_URL")
+        target_registry["repo"] = ENV["DEFAULT_REGISTRY_URL"]
+    end
 
     pp = ProcessedParams(rp)
     @info("Processing register event", reponame=rp.reponame, target_registry_name)
@@ -138,7 +144,7 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
             regp = RegisterParams(pp.cloneurl,
                                   pp.project,
                                   pp.tree_sha;
-                                  registry=get(ENV, "DEFAULT_REGISTRY_URL", get(target_registry, "repo")),
+                                  registry=target_registry["repo"],
                                   registry_deps=registry_deps,
                                   push=true,
                                   )

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -138,7 +138,7 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
             regp = RegisterParams(pp.cloneurl,
                                   pp.project,
                                   pp.tree_sha;
-                                  registry=target_registry["repo"],
+                                  registry=get(ENV, "DEFAULT_REGISTRY_URL", get(target_registry, "repo")),
                                   registry_deps=registry_deps,
                                   push=true,
                                   )

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -205,7 +205,8 @@ function main(config::AbstractString=isempty(ARGS) ? "config.toml" : first(ARGS)
     init_registry()
 
     ip = CONFIG["ip"] == "localhost" ? Sockets.localhost : parse(IPAddr, CONFIG["ip"])
-    port = CONFIG["port"]
+    #port = CONFIG["port"]
+    port=get(CONFIG, "port", parse(Int, get(ENV, "PORT", "8001")))
 
     @info "Starting WebUI" ip port
     monitor = @async status_monitor(CONFIG["stop_file"], event_queue, httpsock)


### PR DESCRIPTION
This PR adds the ability to get the port from ENV for the WebUI.
It also addresses  #74, but allowing URLs for registries to be specified through ENV.

This is useful for services like Heroku where the URL used for the repository contains the access token: `https://USER:TOKEN@github.com/User/Repo`.

I'm not sure, but currently, I don't think the token field in `config.commentbot.toml` is actually used.
Because providing an access token for this field, and then using a normal https URL for the registries results in authentication errors for me, whereas using repo urls of the form, `https://USER:TOKEN@github.com/User/Repo` does not.