### PR TITLE
Add julia compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 
 [compat]
 GitForge = "~0.1.4"
+julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I vaguely recall that Registrator requires Julia 1.1, can someone confirm? @nkottary maybe?