### PR TITLE
Use homedir instead of hard-coding path to home directory

### DIFF
--- a/src/regedit/get_builtin_pkgs.jl
+++ b/src/regedit/get_builtin_pkgs.jl
@@ -2,7 +2,7 @@ import Pkg: TOML
 
 all_pkgs = Dict()
 reg_pkgs = Dict()
-regpath = joinpath("/home", "registrator", ".julia", "registries", "General")
+regpath = joinpath(homedir(), ".julia", "registries", "General")
 cd(regpath)
 isvaliddir(d) = isdir(d) && !startswith(d, ".")
 for d in readdir()


### PR DESCRIPTION
This is a quality of life improvement for people running Registrator on a system with a user account not called "registrator." It's otherwise equivalent.