### PR TITLE
Doc gen docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The Julia package manager **does not** rely on git tags and GitHub releases. How
 
 The docs for your project will be automatically built by [DocumentationGenerator.jl](https://github.com/JuliaDocs/DocumentationGenerator.jl). Please see that repo for details. Your docs should show up at pkg.julialang.org/docs.
 
+By default, whatever is in `docs/make.jl` will be built, or it will fall back to using your README.md.
+
 ## Approving pull requests on the registry
 
 Currently, a registry maintainer will manually merge the pull request made by Registrator.  We will soon have a CI system to check and auto-merge without human intervention.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Note that if you have not enabled TagBot, no release will be made at all, and so
 
 The Julia package manager **does not** rely on git tags and GitHub releases. However, Registrator will generate a `git tag` command for you to optionally create a corresponding tag with your package version, or you can use TagBot as is mentioned above.
 
+### Note on documentation build
+
+The docs for your project will be automatically built by [DocumentationGenerator.jl](https://github.com/JuliaDocs/DocumentationGenerator.jl). Please see that repo for details. Your docs should show up at pkg.julialang.org/docs.
+
 ## Approving pull requests on the registry
 
 Currently, a registry maintainer will manually merge the pull request made by Registrator.  We will soon have a CI system to check and auto-merge without human intervention.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The Julia package manager **does not** rely on git tags and GitHub releases. How
 
 The docs for your project will be automatically built by [DocumentationGenerator.jl](https://github.com/JuliaDocs/DocumentationGenerator.jl). Please see that repo for details. Your docs should show up at pkg.julialang.org/docs.
 
-By default, whatever is in `docs/make.jl` will be built, or it will fall back to using your README.md.
+By default, `docs/make.jl` will be run to build the docs. If that is missing, the `README.md` will be used instead.
 
 ## Approving pull requests on the registry
 


### PR DESCRIPTION
Add some minimal documentation regarding how the docs for packages will be built. This at least provides a starting point for new people to look to when trying to figure out how packages are added and docs built by Registrator.