### PR TITLE
Allow GitHub Actions to trigger the Registrator GitHub app

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -33,6 +33,7 @@ is_owned_by_organization(event) = event.repository.owner.typ == "Organization"
 function is_comment_by_collaborator(event)
     @debug("Checking if comment is by collaborator")
     user = get_user_login(event.payload)
+    user == "github-actions[bot]" && return true
     return iscollaborator(event.repository, user; auth=get_access_token(event))
 end
 
@@ -40,6 +41,7 @@ function is_comment_by_org_owner_or_member(event)
     @debug("Checking if comment is by repository parent organization owner or member")
     org = event.repository.owner.login
     user = get_user_login(event.payload)
+    user == "github-actions[bot]" && return true
     if get(CONFIG, "check_private_membership", false)
         return GitHub.check_membership(org, user; auth=get_user_auth())
     else


### PR DESCRIPTION
The GitHub Actions token (`GITHUB_TOKEN`) has write permissions on the repo on which the action is installed, and no permissions on other repos.

So, if we see a commit comment inside the `Foo.jl` repository, and the comment is made by the `github-actions[bot]` user, then we know that the comment was made by a GitHub Action installed on the `Foo.jl` repository.

Therefore, I think that we should allow the `github-actions[bot]` user to trigger Registrator.

This pull request allows the `github-actions[bot]` user to trigger Registrator on repos owned by individual users and repos owned by organizations.