### PR TITLE
Make trigger phrase case-insensitive

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -203,10 +203,12 @@ function comment_handler(event::WebhookEvent, phrase::RegexMatch)
     return HTTP.Messages.Response(200)
 end
 
+make_trigger(cfg=CONFIG) = Regex(cfg["trigger"] * "(.*)", "i")
+
 function github_webhook(http_ip=CONFIG["http_ip"],
                         http_port=get(CONFIG, "http_port", parse(Int, get(ENV, "PORT", "8001"))))
     auth = get_jwt_auth()
-    trigger = Regex(CONFIG["trigger"] * "(.*)")
+    trigger = make_trigger()
     listener = GitHub.CommentListener(comment_handler, trigger; check_collab=false, auth=auth, secret=CONFIG["github"]["secret"])
     httpsock[] = Sockets.listen(IPv4(http_ip), http_port)
 

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,8 +1,16 @@
-import Registrator.CommentBot: parse_comment
+using Registrator.CommentBot: make_trigger, parse_comment
 
 using Test
 
 @testset "Server" begin
+
+@testset "Trigger comment" begin
+    trigger = make_trigger(Dict("trigger" => "@JuliaRegistrator"))
+    @test match(trigger, "@JuliaRegistrator hi") !== nothing
+    @test match(trigger, "@juliaregistrator hi") !== nothing
+    @test match(trigger, "@Zuliaregistrator hi") === nothing
+    @test match(trigger, "@zuliaregistrator hi") === nothing
+end
 
 @testset "parse_comment" begin
     @test parse_comment("register()") == ("register", Dict{Symbol,String}())


### PR DESCRIPTION
This lets us use `@juliaregistrator register` (fixes a gripe mentioned on Slack).