### PR TITLE
Update stop-* make commands to correct file paths

### DIFF
--- a/run/config.commentbot.toml
+++ b/run/config.commentbot.toml
@@ -8,7 +8,7 @@ backend_port = 5555             # Port of the backend regservice
 trigger = "@JuliaRegistrator"   # The comment that should trigger Registrator. Typically
                                 # keep this the same as your GitHub user mention.
 
-stop_file = "/tmp/stopcommentbot" # `touch` this file to stop the comment bot
+stop_file = "stopcommentbot" # `touch` this file to stop the comment bot
 
 issue_repo = "JuliaRegistries/Registrator.jl"
 report_issue = false            # If set to true any unhandled error will be reported as

--- a/run/config.regservice.toml
+++ b/run/config.regservice.toml
@@ -1,5 +1,5 @@
 [regservice]
-stop_file = "/tmp/stopregservice"    # `touch` this file to stop the registration service
+stop_file = "stopregservice"    # `touch` this file to stop the registration service
 log_level = "debug"
 port = 5555     # Port on which to serve registration service
 user = ""

--- a/run/makefile
+++ b/run/makefile
@@ -1,11 +1,11 @@
 stop-regservice:
-	touch stopregservice
+	touch /tmp/stopregservice
 
 stop-commentbot:
-	touch stopcommentbot
+	touch /tmp/stopcommentbot
 
 stop-webui:
-	touch stopwebui
+	touch /tmp/stopwebui
 
 stop-all: stop-regservice stop-commentbot stop-webui
 

--- a/run/makefile
+++ b/run/makefile
@@ -1,11 +1,11 @@
 stop-regservice:
-	touch /tmp/stopregservice
+	touch stopregservice
 
 stop-commentbot:
-	touch /tmp/stopcommentbot
+	touch stopcommentbot
 
 stop-webui:
-	touch /tmp/stopwebui
+	touch stopwebui
 
 stop-all: stop-regservice stop-commentbot stop-webui
 


### PR DESCRIPTION
Currently, the default config for the commentbot, regservice and webui is to listen for file-creations in the /tmp/ folder, but the default behavior for the make command is to create the stop-files in the working directory. This pr changes the latter to create the files in /tmp/, as expected