### PR TITLE
Fix slack backtrace

### DIFF
--- a/src/slack.jl
+++ b/src/slack.jl
@@ -4,6 +4,6 @@ function post_on_slack_channel(msg, token, channel)
     try
         HTTP.get("https://slack.com/api/chat.postMessage?token=$token&channel=$channel&as_user=true&text=$(escapeuri(msg))")
     catch ex
-        @info("Error while posting to slack channel: $(get_backtrace(ex))")
+        @info("Error while posting to slack channel: $(sprint(Base.showerror, ex, catch_backtrace()))")
     end
 end


### PR DESCRIPTION
the toplevel file `Registrator.jl` includes `slack.jl` but not `management.jl`, so the function `get_backtrace` which is defined in `management.jl` is not available within the `post_on_slack_channel` function. 
We could of course include the management file first before the `slack.jl` file, but there's a lot of stuff defined in there, so I figured it might be better to just manually inline the `get_backtrace` function into `post_on_slack_channel`