### PR TITLE
Add in email field to commentbot config

### DIFF
--- a/run/config.commentbot.toml
+++ b/run/config.commentbot.toml
@@ -47,7 +47,9 @@ registry_deps = ["https://github.com/JuliaRegistries/General"]
 
 [commentbot.github]
 user = ""       # A GitHub user ID, can be same as that set for [regservice]
-
+email = ""      # The email associated with the above user, this is
+                # required for creating the tag in the approval process. Note that this 
+                # is only needed if you want to enable the approval process.
 token = ""      # An access token for the above user ID, this is
                 # required for pushing the commit to the remote registry
 


### PR DESCRIPTION
The approval process needs an email in order to create a tag in the source repo, https://github.com/JuliaRegistries/Registrator.jl/blob/master/src/commentbot/approval.jl#L3

That line is currently missing from the commentbot's config, which leads to an error in the approval call. This PR just adds a line to the config as a prompt to add in the email