### PR TITLE
Bump version from "1.1.1" to "1.2.0"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"


### PR DESCRIPTION
I looked at the commits made to master since 1.1.1, and they all seem to me like they are bug fixes or new features.