### PR TITLE
Bump version from "1.2.1" to "1.2.2"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"


### PR DESCRIPTION
There has been one commit (a bug fix) merged to master since the last release (1.2.1).

This PR bumps the version to 1.2.2. After it is merged, we can make a new release.