### PR TITLE
Add the `check_authorization` kwarg to the `Registrator.WebUI.register` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -1,5 +1,5 @@
 # Step 5: Register the package (maybe).
-function register(r::HTTP.Request)
+function register(r::HTTP.Request; check_authorization::Bool=true)
     r.method == "POST" || return json(405; error="Method not allowed")
 
     state = getcookie(r, "state")
@@ -30,8 +30,10 @@ function register(r::HTTP.Request)
     owner, name = splitrepo(package)
     repo = getrepo(u.forge, owner, name)
     repo === nothing && return json(400; error="Repository was not found")
-    isauthorized(u, repo) || return json(400; error="Unauthorized to release this package")
-
+    if check_authorization
+        isauthorized(u, repo) || return json(400; error="Unauthorized to release this package")
+    end
+    
     # Get the (Julia)Project.toml, and make sure it is valid.
     toml = gettoml(u.forge, repo, ref)
     toml === nothing && return json(400; error="(Julia)Project.toml was not found")


### PR DESCRIPTION
This pull request makes the following changes:
1. Adds the `check_authorization::Bool` keyword argument to the `Registrator.WebUI.register` function. The default value is `check_authorization = true`.
2. Bumps the version number in `Project.toml` from `1.2.2` to `1.3.0`.

## Motivation

I am working on an alternate way of deploying Registrator.jl that does not require a persistent server to be running. As part of this, I hook into Registrator at the `register` function. However, I check that the user is authorized to make releases of the package before I call this function, so there is no need to repeat this check inside the `register` function. Therefore, I need to be able to disable this check.