### PR TITLE
Add 'origin/' prefix to branch in git rev-parse

### DIFF
--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -168,7 +168,7 @@ function gettreesha(
             run(`git clone $url $dest`)
 
             if isdir(joinpath(dest, subdir))
-                readchomp(`git -C $dest rev-parse $ref:$subdir`), ""
+                readchomp(`git -C $dest rev-parse origin/$ref:$subdir`), ""
             else
                 nothing, "The sub-directory $subdir does not exist in this repository"
             end


### PR DESCRIPTION
It seems `git rev-parse <branch-name>:` only works for default branches and checked out branches. For remote branches we need to add `origin/` as a prefix.