### PR TITLE
Do a bare clone when getting tree SHA

### DIFF
--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -165,10 +165,10 @@ function gettreesha(
     return try
         mktempdir() do dir
             dest = joinpath(dir, r.name)
-            run(`git clone $url $dest`)
+            run(`git clone --bare $url $dest`)
 
             if isdir(joinpath(dest, subdir))
-                readchomp(`git -C $dest rev-parse origin/$ref:$subdir`), ""
+                readchomp(`git -C $dest rev-parse $ref:$subdir`), ""
             else
                 nothing, "The sub-directory $subdir does not exist in this repository"
             end


### PR DESCRIPTION
Doing a bare git clone:
* Makes all the remote branches local
* Gives us all the tags

Its also slightly faster than just clone.

This will fix https://github.com/JuliaRegistries/Registrator.jl/issues/339 and also correctly fixes what https://github.com/JuliaRegistries/Registrator.jl/pull/335 tried to fix