### PR TITLE
add description field

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -75,6 +75,8 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
                   "maintainer_can_modify"=>true)
     ref = get_html_url(rp.evt.payload)
 
+    description = something(rp.evt.repository.description, "")
+
     params["title"], params["body"] = pull_request_contents(;
         registration_type=get(rbrn.metadata, "kind", ""),
         package=name,
@@ -86,6 +88,7 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         reviewer="@$reviewer",
         reference=ref,
         meta=enc_meta,
+        description=description,
     )
 
     repo = join(split(target_registry["repo"], "/")[end-1:end], "/")

--- a/src/pull_request.jl
+++ b/src/pull_request.jl
@@ -13,6 +13,7 @@ function pull_request_contents(;
     reviewer::AbstractString="",
     reference::AbstractString="",
     meta::AbstractString="",
+    description::AbstractString="",
 )
     title = if isempty(registration_type)
         "Registering: $package v$version"
@@ -32,6 +33,7 @@ function pull_request_contents(;
     isempty(gitref) || push!(lines, "- Git reference: $gitref")
     isempty(reviewer) || push!(lines, "- Reviewed by: $reviewer")
     isempty(reference) || push!(lines, "- Reference: $reference")
+    isempty(description) || push!(lines, "- Description: $description")
     isempty(release_notes) || push!(
         lines,
         "- Release notes:",

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -148,6 +148,8 @@ function action(regdata::RegistrationData, zsock::RequestSocket)
         end
         state = :errored
     else
+        description = something(regdata.repo.description, "")
+
         title, body = pull_request_contents(;
             registration_type=get(branch.metadata, "kind", ""),
             package=regdata.project.name,
@@ -157,6 +159,7 @@ function action(regdata::RegistrationData, zsock::RequestSocket)
             version=regdata.project.version,
             commit=regdata.commit,
             release_notes=regdata.notes,
+            description=description,
         )
 
         # Make the PR.


### PR DESCRIPTION
Over in https://github.com/JuliaRegistries/General/issues/43776 it was suggested that it might be nice to have the repo description field in the PR comment. We could then grab it from the PR comment and send it downstream as well, e.g. to the Slack channel `#new-packages-feed`, along with the release notes.

From the WebUI or CommentBot we seem to have a `repo` object with this field, so we can get the description without an additional API call. However, I'm not sure if it is always populated or not; if it is not populated, then we'd need to make an API call to fill out the fields (`repo` in the comment bot to use GitHub.jl, or `get_repo` in the WebUI to use GitForge.jl).