### PR TITLE
Option to push registration commits to a fork of the registry repo

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -226,9 +226,9 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "SHA", "UUIDs"]
-git-tree-sha1 = "e5bc4ecbdd55f030b9f2644aa4a625f34a868ea0"
+git-tree-sha1 = "7ba3c65d4f40a399e5a2f0ec5abc89de871604e5"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
-version = "1.6.0"
+version = "1.7.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.2.9"
+version = "1.3.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
@@ -37,7 +37,7 @@ MbedTLS = "0.6.8, 0.7, 1"
 Mocking = "0.7"
 Mustache = "0.5, 1.0"
 Mux = "0.7"
-RegistryTools = "1.5.0"
+RegistryTools = "1.7"
 TimeToLive = "0.2, 0.3"
 ZMQ = "1"
 julia = "1.1"

--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -92,6 +92,8 @@ It's important to note that optional values **must** be omitted or commented out
 
 - `registry_clone_url`: Your registry's clone URL.
   This defaults to `registry_url`, but you can use this value to clone the registry via SSH, for example.
+- `registry_fork_url`: URL for forked registry repository.
+  Registration commits will be pushed to the repo pointed to by this URL. This defaults to `registry_clone_url`.
 - `extra_providers`: Path to a Julia file that adds extra providers.
   This should only be used for certain cases when your provider is self-hosted (see next section).
 - `registry_provider`: The registry provider, which is usually inferred from the registry URL.

--- a/run/config.commentbot.toml
+++ b/run/config.commentbot.toml
@@ -67,7 +67,8 @@ app_id = 12345  # The app ID for your GitHub app. This can be found in
 priv_pem = "private-key.pem"    # The private key file of your GitHub app
 
 [commentbot.targets.qux]   # You can define additional targets as [targets.baz], [targets.foo] etc.
-repo = "https://github.com/your_github_id/QuxRegistry"
+repo = "https://github.com/organization/QuxRegistry"
+fork_repo = "https://github.com/registrator/QuxRegistry"
 base_branch = "master"
 
 [commentbot.slack]

--- a/run/config.web.toml
+++ b/run/config.web.toml
@@ -8,6 +8,7 @@ registry_url = ""
 stop_file = "stopwebui"
 # log_level = "INFO"
 # registry_clone_url = ""
+# registry_fork_url = ""
 # extra_providers = ""
 # registry_provider = ""
 # registry_deps = []

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -214,9 +214,11 @@ end
 const REGISTRATOR_CONTROLLED_LABELS = ["new package", "major release", "minor release",
                                        "patch release", "BREAKING"]
 
-function create_or_find_pull_request(repo::AbstractString,
-                                     params::Dict{<:AbstractString, Any},
-                                     rbrn::RegBranch)
+function create_or_find_pull_request(
+    repo::AbstractString,
+    params::Dict{<:AbstractString, Any},
+    rbrn::RegBranch
+)
     pr = nothing
     msg = ""
     auth = get_user_auth()
@@ -244,7 +246,7 @@ function create_or_find_pull_request(repo::AbstractString,
         prs, _ = pull_requests(repo; auth=auth, params=Dict(
             "state" => "open",
             "base" => params["base"],
-            "head" => string(split(repo, "/")[1], ":", params["head"]),
+            "head" => params["head"],
         ))
         if !isempty(prs)
             @assert length(prs) == 1 "PR lookup should only contain one result"

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -37,7 +37,9 @@ include("providers.jl")
 struct Registry{F <: GitForge.Forge, R}
     forge::F
     repo::R
+    fork_repo::R
     url::String
+    fork_url::String
     clone::String
     deps::Vector{String}
     enable_release_notes::Bool
@@ -109,10 +111,19 @@ function init_registry()
     owner, name = splitrepo(url)
     repo = @gf get_repo(forge, owner, name)
     repo === nothing && error("Registry lookup failed")
+
     clone = get(CONFIG, "registry_clone_url", url)
+    fork_url = get(CONFIG, "registry_fork_url", clone)
+    fork_owner, fork_name = splitrepo(fork_url)
+    fork_repo = @gf get_repo(forge, fork_owner, fork_name)
+    fork_repo === nothing && error("Registry fork lookup failed")
+
     deps = map(String, get(CONFIG, "registry_deps", String[]))
     enable_release_notes = !get(CONFIG, "disable_release_notes", false)
-    REGISTRY[] = Registry(forge, repo, url, clone, deps, enable_release_notes)
+    REGISTRY[] = Registry(
+        forge, repo, fork_repo, url, fork_url, clone,
+        deps, enable_release_notes
+    )
 end
 
 for f in [:index, :auth, :callback, :select, :register]
@@ -136,6 +147,7 @@ function action(regdata::RegistrationData, zsock::RequestSocket)
         regdata.tree;
         subdir=regdata.subdir,
         registry=REGISTRY[].clone, 
+        registry_fork=REGISTRY[].fork_url,
         registry_deps=REGISTRY[].deps, 
         push=true,
     )

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -209,8 +209,9 @@ function make_registration_request(
     repoid = r.repo.id
     base = r.repo.default_branch
     result = create_pull_request(
-        r.forge, repoid;
+        r.forge, REGISTRY[].fork_repo.id;
         source_branch=branch,
+        target_project_id=repoid,
         target_branch=base,
         title=title,
         description=body,
@@ -240,9 +241,11 @@ function make_registration_request(
     owner = r.repo.owner.login
     repo = r.repo.name
     base = r.repo.default_branch
+    head = string(REGISTRY[].fork_repo.owner.login, ":", branch)
+
     result = create_pull_request(
         r.forge, owner, repo;
-        head=branch,
+        head=head,
         base=base,
         title=title,
         body=body,
@@ -254,11 +257,11 @@ function make_registration_request(
         map(e -> get(e, "message", ""), get(data, "errors", []))
     end
     if !exists
-        @error "Exception making registration request" owner=owner repo=repo base=base head=branch
+        @error "Exception making registration request" owner=owner repo=repo base=base head=head
         return result
     end
 
-    prs = get_pull_requests(r.forge, owner, repo; head="$owner:$branch", base=base, state="open")
+    prs = get_pull_requests(r.forge, owner, repo; head=head, base=base, state="open")
     val = GitForge.value(prs)
     @assert length(val) == 1
     prid = first(val).number


### PR DESCRIPTION
Motivation: We would like to use a fork of the registry repo to make registration pull requests. This would allow us to make registration requests without requiring that Registrator have write access to the Registry repo.

Description of changes: Added a new configuration parameter to configure the Registry fork's URL. If this is unspecified it defaults to the clone URL.

Dependencies: https://github.com/JuliaRegistries/RegistryTools.jl/pull/68