### PR TITLE
Add release notes note if no release notes provided

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -97,25 +97,37 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
     pr, msg = create_or_find_pull_request(repo, params, rbrn)
     tag = tag_name(ver, subdir)
-    
-    releasenotes_note if isempty(rp.release_notes)
+
+    releasenotes_note = if isempty(rp.release_notes)
         """
-        
+
         ### Tip: Release Notes
-        
-        Did you know you can add release notes too? Just add markdown formatted text underneath the comment and it will be added to 
-        the registry PR, and if tagbot is installed it will also be added to the tag created on this repository.
-        
+
+        Did you know you can add release notes too? Just add markdown formatted text underneath the comment with the header
+        "Release notes:" and it will be detected and added to the registry PR, and if tagbot is installed it will also
+        be added to the tag created on this repository.
+
+        i.e.
+        ```
+        @JuliaRegistrator register()
+
+        Release notes:
+
+        ## Breaking changes
+
+        - Foo
+        ```
+
         """
     else
         ""
     end
-    
+
     cbody = """
         Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
         $(releasenotes_note)
         ### Tagging
-    
+
         After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.
 
         This will be done automatically if the [Julia TagBot GitHub Action](https://github.com/marketplace/actions/julia-tagbot) is installed, or can be done manually through the github interface, or via:

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -104,8 +104,8 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         ### Tip: Release Notes
 
         Did you know you can add release notes too? Just add markdown formatted text underneath the comment after the text
-        "Release notes:" and it will be detected and added to the registry PR, and if TagBot is installed it will also
-        be added to the release created on this repository. i.e.
+        "Release notes:" and it will be added to the registry PR, and if TagBot is installed it will also be added to the
+        release that TagBot creates. i.e.
 
         ```
         @JuliaRegistrator register

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -103,20 +103,21 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
         ### Tip: Release Notes
 
-        Did you know you can add release notes too? Just add markdown formatted text underneath the comment with the header
-        "Release notes:" and it will be detected and added to the registry PR, and if tagbot is installed it will also
-        be added to the tag created on this repository.
+        Did you know you can add release notes too? Just add markdown formatted text underneath the comment after the text
+        "Release notes:" and it will be detected and added to the registry PR, and if TagBot is installed it will also
+        be added to the release created on this repository. i.e.
 
-        i.e.
         ```
-        @JuliaReg... register()
+        @JuliaRegistrator register
 
         Release notes:
 
         ## Breaking changes
 
-        - Foo
+        - blah
         ```
+
+        To add them here just re-invoke and the PR will be updated.
 
         """
     else

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -109,7 +109,7 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
         i.e.
         ```
-        @JuliaRegistrator register()
+        @JuliaReg... register()
 
         Release notes:
 

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -97,10 +97,25 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
     pr, msg = create_or_find_pull_request(repo, params, rbrn)
     tag = tag_name(ver, subdir)
-
+    
+    releasenotes_note if isempty(rp.release_notes)
+        """
+        
+        ### Tip: Release Notes
+        
+        Did you know you can add release notes too? Just add markdown formatted text underneath the comment and it will be added to 
+        the registry PR, and if tagbot is installed it will also be added to the tag created on this repository.
+        
+        """
+    else
+        ""
+    end
+    
     cbody = """
         Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
-
+        $(releasenotes_note)
+        ### Tagging
+    
         After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.
 
         This will be done automatically if the [Julia TagBot GitHub Action](https://github.com/marketplace/actions/julia-tagbot) is installed, or can be done manually through the github interface, or via:


### PR DESCRIPTION
Untested, but should look something like this:
____

```
@JuliaRegistrator register()
```
____

Registration pull request created: JuliaRegistries/General/xxxx

### Tip: Release Notes
        
Did you know you can add release notes too? Just add markdown formatted text underneath the comment and it will be added to the registry PR, and if tagbot is installed it will also be added to the tag created on this repository.

### Tagging
After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.

This will be done automatically if the Julia TagBot GitHub Action is installed, or can be done manually through the github interface, or via:
```
git tag -a v1.3.1 -m "<description of version>" 7d4c8c4c918148afc371e4814d1f2929c3f46b37
git push origin v1.3.1
```