### PR TITLE
RFC: CLI entrypoint

### DIFF
--- a/src/CLI.jl
+++ b/src/CLI.jl
@@ -1,0 +1,116 @@
+
+using GitForge, GitForge.GitHub, GitForge.GitLab
+using Logging
+using RegistryTools
+using TOML
+include("Registrator.jl")
+
+using Registrator.WebUI: get_log_level
+
+function main(config::AbstractString=isempty(ARGS) ? "config.toml" : first(ARGS))
+    merge!(Registrator.WebUI.CONFIG, TOML.parsefile(config)["web"])
+    if get(Registrator.WebUI.CONFIG, "enable_logging", true)
+        global_logger(SimpleLogger(stdout, get_log_level(get(Registrator.WebUI.CONFIG, "log_level", "INFO"))))
+    end
+
+    @show Registrator.WebUI.CONFIG
+
+    # Based on Registrator.WebUI.init_providers()
+    gitlab = Registrator.WebUI.CONFIG["gitlab"]
+    Registrator.WebUI.PROVIDERS["gitlab"] = Registrator.WebUI.Provider(;
+        name="GitLab",
+        client=GitLabAPI(;
+            url=get(gitlab, "api_url", GitLab.DEFAULT_URL),
+            token=PersonalAccessToken(gitlab["token"]),
+            has_rate_limits=!get(gitlab, "disable_rate_limits", false),
+        ),
+        client_id=gitlab["client_id"],
+        client_secret=gitlab["client_secret"],
+        auth_url=get(gitlab, "auth_url", "https://gitlab.com/oauth/authorize"),
+        token_url=get(gitlab, "token_url", "https://gitlab.com/oauth/token"),
+        scope="read_user api",
+        include_state=false,
+        token_type=OAuth2Token,
+    )
+
+    Registrator.WebUI.init_registry()
+    
+    register()
+end
+
+
+function register()
+    pkey = "gitlab"
+
+    provider = get(Registrator.WebUI.PROVIDERS, pkey, nothing)
+    # client = typeof(provider.client)(;
+    #     url=GitForge.base_url(provider.client),
+    #     token=provider.token_type(token),
+    #     has_rate_limits=GitForge.has_rate_limits(provider.client, identity),
+    # )
+    client = provider.client # Not sure what I'm doing here. Skipping oauth token dance I guess?
+    u = Registrator.WebUI.User(@Registrator.WebUI.gf(get_user(client)), client)
+    @show client
+    @show u
+
+    # TODO read these from CLI args
+    package = "https://gitlab.company.com/Example.jl/"
+    ref = "main"
+    notes = ""
+    subdir = ""
+    regdata = Registrator.WebUI.build_registration_data(u, package, ref, notes, subdir)
+
+
+    # Based on WebUI.jl action()
+    regp = RegistryTools.RegisterParams(
+        Registrator.WebUI.cloneurl(regdata.repo, regdata.is_ssh), 
+        regdata.project, 
+        regdata.tree;
+        subdir=regdata.subdir,
+        registry=Registrator.WebUI.REGISTRY[].clone, 
+        registry_deps=Registrator.WebUI.REGISTRY[].deps, 
+        push=true,
+    )
+
+    # Based on RegService.jl service()
+    # TODO read from config
+    regp.gitconfig["user.name"] = "Registrar"
+    # regp.gitconfig["user.email"] = ""
+    branch = RegistryTools.register(regp)
+
+    # Based on WebUI.jl action()
+    if branch === nothing || get(branch.metadata, "error", nothing) !== nothing
+        if branch === nothing
+            msg = "ERROR: Registrator backend service unreachable"
+        else
+            msg = "Registration failed: " * branch.metadata["error"]
+        end
+        state = :errored
+    else
+        description = something(regdata.repo.description, "")
+
+        title, body = pull_request_contents(;
+            registration_type=get(branch.metadata, "kind", ""),
+            package=regdata.project.name,
+            repo=web_url(regdata.repo),
+            user=display_user(regdata.user),
+            gitref=regdata.ref,
+            version=regdata.project.version,
+            commit=regdata.commit,
+            release_notes=regdata.notes,
+            description=description,
+        )
+
+        # Make the PR.
+        pr = @Registrator.WebUI.gf make_registration_request(Registrator.WebUI.REGISTRY[], branch.branch, title, body)
+        if pr === nothing
+            msg = "Registration failed: Making pull request failed"
+            state = :errored
+        else
+            url = web_url(pr)
+            msg = """Registry PR successfully created, see it <a href="$url" target="_blank">here</a>!"""
+            state = :success
+        end
+    end
+    @debug msg
+end

--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -1,3 +1,8 @@
+
+
+
+
+
 # Step 5: Register the package (maybe).
 function register(r::HTTP.Request)
     r.method == "POST" || return json(405; error="Method not allowed")
@@ -12,6 +17,28 @@ function register(r::HTTP.Request)
     form = parseform(String(r.body))
     package = get(form, "package", "")
     isempty(package) && return json(400; error="Package URL was not provided")
+    ref = get(form, "ref", "")
+    isempty(ref) && return json(400; error="Branch was not provided")
+    notes = get(form, "notes", "")
+    subdir = get(form, "subdir", "")
+
+    try
+        regdata = build_registration_data(u, package, ref, notes, subdir)
+    catch e
+        status = if e isa ArgumentError
+            400
+        else
+            500
+        end
+        return json(status; error=e.msg)
+    end
+
+    REGISTRATIONS[regdata.commit] = RegistrationState("Please wait...", :pending)
+    put!(event_queue, regdata)
+    return json(; message="Registration in progress...", id=commit)
+end
+
+function build_registration_data(u::User, package::AbstractString, ref::AbstractString, notes::AbstractString, subdir::AbstractString)
     is_ssh = startswith(package, "git@") && occursin(":", package)
     if !is_ssh && !occursin("://", package)
          package = "https://$package"
@@ -19,49 +46,41 @@ function register(r::HTTP.Request)
     if endswith(package, ".git")
         package = package[1:end-length(".git")]
     end
-    !is_ssh && match(r"https?://.*\..*/.*/.*", package) === nothing && return json(400; error="Package URL is invalid")
-    is_ssh && match(r"git@.*\..*:.*/.*", package) === nothing && return json(400; error="Package URL is invalid")
-
-    ref = get(form, "ref", "")
-    isempty(ref) && return json(400; error="Branch was not provided")
-    notes = get(form, "notes", "")
-    subdir = get(form, "subdir", "")
+    !is_ssh && match(r"https?://.*\..*/.*/.*", package) === nothing && throw(ArgumentError("Package URL is invalid"))
+    is_ssh && match(r"git@.*\..*:.*/.*", package) === nothing && throw(ArgumentError("Package URL is invalid"))
 
     # Get the repo, then check for authorization.
     owner, name = splitrepo(package)
     repo = getrepo(u.forge, owner, name)
-    repo === nothing && return json(400; error="Repository was not found")
+    repo === nothing && throw(ArgumentError("Repository was not found"))
     auth_result = isauthorized(u, repo)
     if !is_success(auth_result)
-        return json(400; error="Unauthorized to release this package. Reason: $(auth_result.reason)")
+        throw(ArgumentError("Unauthorized to release this package. Reason: $(auth_result.reason)"))
     end
 
     # Get the (Julia)Project.toml, and make sure it is valid.
     toml = gettoml(u.forge, repo, ref, subdir)
-    toml === nothing && return json(400; error="(Julia)Project.toml was not found")
+    toml === nothing && throw(ArgumentError("(Julia)Project.toml was not found"))
     project = try
         Pkg.Types.read_project(IOBuffer(toml))
     catch e
         @error "Reading project from (Julia)Project.toml failed"
         println(get_backtrace(e))
-        return json(400; error="(Julia)Project.toml is invalid")
+        throw(ArgumentError("(Julia)Project.toml is invalid"))
     end
     for k in [:name, :uuid, :version]
-        getfield(project, k) === nothing && return json(400; error="In (Julia)Project.toml, `$k` is missing or invalid")
+        getfield(project, k) === nothing && throw(ArgumentError("In (Julia)Project.toml, `$k` is missing or invalid"))
     end
 
     commit = getcommithash(u.forge, repo, ref)
-    commit === nothing && return json(500, error="Looking up the commit hash failed")
+    commit === nothing && throw(Exception("Looking up the commit hash failed"))
 
     if istagwrong(u.forge, repo, project.version, commit)
-        return json(400; error="Tag with a different commit already exists for the version mentioned in (Julia)Project.toml")
+        throw(ArgumentError("Tag with a different commit already exists for the version mentioned in (Julia)Project.toml"))
     end
 
     # Register the package,
     tree, errmsg = gettreesha(repo, ref, subdir)
-    tree === nothing && return json(500, error=errmsg)
-    regdata = RegistrationData(project, tree, repo, u.user, ref, commit, notes, is_ssh, subdir)
-    REGISTRATIONS[commit] = RegistrationState("Please wait...", :pending)
-    put!(event_queue, regdata)
-    return json(; message="Registration in progress...", id=commit)
+    tree === nothing && throw(Exception(errmsg))
+    return RegistrationData(project, tree, repo, u.user, ref, commit, notes, is_ssh, subdir)
 end


### PR DESCRIPTION
I'm creating this PR to get some feedback on the idea of having a Command Line Interface (CLI) entrypoint to Registrator.

The use case is that we (at [Invenia](https://github.com/invenia)) want to be able to automatically trigger the registration of package versions when a PR gets merged to the main branch of any repo we have. This would be for our internal GitLab packages, and we'd be using GitLab CI's features to trigger this.

Currently the Registrator has two "entrypoints": the WebUI and the GitHub app. We've been using the WebUI (self-hosted), and while it has been working well, it does add a manual step whenever we release a new package version, which happens often with our ~100 internal packages. Adding automation on top of the WebUI seemed complex and unnecessary, hence why I thought it could make sense to have a simple CLI, which could be used with something like:

```
julia CLI.jl --config path/to/config.toml --package https://gitlab.company.com/Example.jl/ --git-ref master --notes "..."
```

We'd be able to use this in our CI jobs, triggered automatically when PRs are merged. Hopefully this would also benefit others who want to automate registration.

My questions are:

1. Could there be issues in the approach?
  I'm wondering for example if there could be concurrency issues, if we were to trigger the CLI.jl script multiple times in parallel (on different processes or machines). I'm wondering because I see message queues are used internally, and I'm wondering if they serve a concurrence safety purpose (e.g. is it important that only one git process is active at once, or only one registry PR is created at once?). The CLI.jl I propose doesn't use those queues, it's one single-threaded running script.
  
2. Does it make sense to add to Registrator.jl?
  To me it does because it mainly just re-uses the logic found in other files. In the current PR, I've mostly just copied over the code (with a comment indicating where I copied it from), except for one function which I've extracted to see what it would look like to avoid code duplication: `Registrator.WebUI.build_registration_data` (should be moved outside of WebUI).
 
Overall code is very rough and untested, just to show the idea. If we're happy with the approach, I'll submit a proper PR when code is polished and tested.
  
I very appreciate any feedback on this!






