### PR TITLE
Add note for private packages

### DIFF
--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -341,3 +341,7 @@ julia -e '
     using Registrator;
     Registrator.WebUI.main("myconfig.toml")'
 ```
+
+Note for private packages: Organization settings can sometimes restrict third
+party applications like Registrator from using an OAuth token to read a
+private repository. See [Managing OAuth access to your organization's data](https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data).

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -73,7 +73,7 @@ function isauthorized(u::User{GitHub.User}, repo::GitHub.Repo, fetch = true)
         return AuthFailure("Repo $(repo.name) is private")
     jforge = provider(repo).client
     if fetch
-        repo = @gf_q @mock get_repo(u.forge, repo.owner.login, repo.name)
+        repo = @gf @mock get_repo(u.forge, repo.owner.login, repo.name)
     end
     # Users with push access can always release their package
     repo !== nothing && repo.permissions.push && return AuthSuccess()


### PR DESCRIPTION
- Change `@gf_q` to `@gf` for a `get_repo` call so that error is logged
- Add docs for allowing third party OAuth access to private repositories on GitHub