### PR TITLE
Fix WebUI tag check for subdir packages

### DIFF
--- a/src/Registrator.jl
+++ b/src/Registrator.jl
@@ -8,6 +8,8 @@ import RegistryTools
 # Remove all of a base64 string's whitespace before decoding it.
 decodeb64(s::AbstractString) = String(base64decode(replace(s, r"\s" => "")))
 
+tag_name(version, subdir) = subdir == "" ? "v$version" : splitdir(subdir)[end] * "-v$version"
+
 
 struct RegisterParams
     package_repo::String

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -11,7 +11,7 @@ using JSON
 using MbedTLS
 
 import Pkg: TOML
-import ..Registrator: post_on_slack_channel, pull_request_contents
+import ..Registrator: post_on_slack_channel, pull_request_contents, tag_name
 import RegistryTools: RegBranch, Project
 import Base: string
 using ..Messaging
@@ -45,8 +45,6 @@ end
 get_trigger_id(rp::RequestParams{PullRequestTrigger}) = rp.trigger_src.prid
 get_trigger_id(rp::RequestParams{IssueTrigger}) = get_prid(rp.evt.payload)
 get_trigger_id(rp::RequestParams{CommitCommentTrigger}) = get_comment_commit_id(rp.evt)
-
-tag_name(version, subdir) = subdir == "" ? "v$version" : splitdir(subdir)[end] * "-v$version"
 
 reponame_from_url(url::String) = join(split(url, "/")[end-1:end], "/")
 

--- a/src/commentbot/param_types.jl
+++ b/src/commentbot/param_types.jl
@@ -198,7 +198,7 @@ struct ProcessedParams
         end
 
         wrongtag = false
-        if isempty(rp.subdir) && err === nothing
+        if err === nothing
             tag = tag_name(project.version, rp.subdir)
             wrongtag = istagwrong(rp, sha, project.version, auth, tag = tag)
             if wrongtag

--- a/src/commentbot/param_types.jl
+++ b/src/commentbot/param_types.jl
@@ -198,7 +198,7 @@ struct ProcessedParams
         end
 
         wrongtag = false
-        if err === nothing
+        if isempty(rp.subdir) && err === nothing
             tag = tag_name(project.version, rp.subdir)
             wrongtag = istagwrong(rp, sha, project.version, auth, tag = tag)
             if wrongtag

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -1,6 +1,6 @@
 module WebUI
 
-using ..Registrator: pull_request_contents
+using ..Registrator: pull_request_contents, tag_name
 import RegistryTools
 
 using Dates

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -424,8 +424,8 @@ display_user(u::U) where U =
 function istagwrong(
     ::GitHubAPI,
     repo::GitHub.Repo,
-    tag::VersionNumber,
-    commit::String,
+    tag::AbstractString,
+    commit::AbstractString,
 )
     result = @gf get_tags(provider(repo).client, repo.owner.login, repo.name)
 
@@ -452,8 +452,8 @@ end
 function istagwrong(
     ::GitLabAPI,
     project::GitLab.Project,
-    tag::VersionNumber,
-    commit::String,
+    tag::AbstractString,
+    commit::AbstractString,
 )
     # Using Registrator's token here instead of the users. This is
     # because the user oauth scope needs to include "api" in order to
@@ -485,8 +485,8 @@ end
 function istagwrong(
     api::BitbucketAPI,
     repo::Bitbucket.Repo,
-    tag::VersionNumber,
-    commit::String,
+    tag::AbstractString,
+    commit::AbstractString,
 )
     try
         # Using Registrator's token here instead of the users. This is

--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -52,7 +52,8 @@ function register(r::HTTP.Request)
     commit = getcommithash(u.forge, repo, ref)
     commit === nothing && return json(500, error="Looking up the commit hash failed")
 
-    if istagwrong(u.forge, repo, project.version, commit)
+    # Skip tag check for subdir packages
+    if isempty(subdir) && istagwrong(u.forge, repo, project.version, commit)
         return json(400; error="Tag with a different commit already exists for the version mentioned in (Julia)Project.toml")
     end
 

--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -52,8 +52,8 @@ function register(r::HTTP.Request)
     commit = getcommithash(u.forge, repo, ref)
     commit === nothing && return json(500, error="Looking up the commit hash failed")
 
-    # Skip tag check for subdir packages
-    if isempty(subdir) && istagwrong(u.forge, repo, project.version, commit)
+    tag = tag_name(project.version, subdir)
+    if istagwrong(u.forge, repo, tag, commit)
         return json(400; error="Tag with a different commit already exists for the version mentioned in (Julia)Project.toml")
     end
 


### PR DESCRIPTION
~The `istagwrong` method checks whether the commit SHA of the registration ref matches the commit SHA of the corresponding tag (if such a tag exists). This does not work for subdir packages since their versions need not be same as the repo tag. This PR skips the tag check when subdir is non-empty~