### PR TITLE
WIP: Automatically look up release notes from repo if no release notes explicitly provided

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -97,25 +97,37 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
     pr, msg = create_or_find_pull_request(repo, params, rbrn)
     tag = tag_name(ver, subdir)
-    
-    releasenotes_note if isempty(rp.release_notes)
+
+    releasenotes_note = if isempty(rp.release_notes)
         """
-        
+
         ### Tip: Release Notes
-        
-        Did you know you can add release notes too? Just add markdown formatted text underneath the comment and it will be added to 
-        the registry PR, and if tagbot is installed it will also be added to the tag created on this repository.
-        
+
+        Did you know you can add release notes too? Just add markdown formatted text underneath the comment with the header
+        "Release notes:" and it will be detected and added to the registry PR, and if tagbot is installed it will also
+        be added to the tag created on this repository.
+
+        i.e.
+        ```
+        @JuliaRegistrator register()
+
+        Release notes:
+
+        ## Breaking changes
+
+        - Foo
+        ```
+
         """
     else
         ""
     end
-    
+
     cbody = """
         Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
         $(releasenotes_note)
         ### Tagging
-    
+
         After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.
 
         This will be done automatically if the [Julia TagBot GitHub Action](https://github.com/marketplace/actions/julia-tagbot) is installed, or can be done manually through the github interface, or via:

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -104,8 +104,8 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         ### Tip: Release Notes
 
         Did you know you can add release notes too? Just add markdown formatted text underneath the comment after the text
-        "Release notes:" and it will be detected and added to the registry PR, and if TagBot is installed it will also
-        be added to the release created on this repository. i.e.
+        "Release notes:" and it will be added to the registry PR, and if TagBot is installed it will also be added to the
+        release that TagBot creates. i.e.
 
         ```
         @JuliaRegistrator register

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -103,20 +103,21 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
         ### Tip: Release Notes
 
-        Did you know you can add release notes too? Just add markdown formatted text underneath the comment with the header
-        "Release notes:" and it will be detected and added to the registry PR, and if tagbot is installed it will also
-        be added to the tag created on this repository.
+        Did you know you can add release notes too? Just add markdown formatted text underneath the comment after the text
+        "Release notes:" and it will be detected and added to the registry PR, and if TagBot is installed it will also
+        be added to the release created on this repository. i.e.
 
-        i.e.
         ```
-        @JuliaReg... register()
+        @JuliaRegistrator register
 
         Release notes:
 
         ## Breaking changes
 
-        - Foo
+        - blah
         ```
+
+        To add them here just re-invoke and the PR will be updated.
 
         """
     else

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -81,6 +81,16 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
     description = something(rp.evt.repository.description, "")
 
+    release_notes, releasenotes_source = if !isempty(rp.release_notes)
+        # these came from the invoke
+        rp.release_notes, :invoke
+    elseif pp.release_notes isa String && !isempty(pp.release_notes)
+        # these came from the changelog search
+        pp.release_notes, :changelog
+    else
+        "", :none
+    end
+
     params["title"], params["body"] = pull_request_contents(;
         registration_type=get(rbrn.metadata, "kind", ""),
         package=name,
@@ -88,7 +98,7 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         user="$(mention(creator))",
         version=ver,
         commit=pp.sha,
-        release_notes=rp.release_notes,
+        release_notes=release_notes,
         reviewer="$(mention(reviewer))",
         reference=ref,
         meta=enc_meta,
@@ -98,7 +108,21 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
     pr, msg = create_or_find_pull_request(repo, params, rbrn)
     tag = tag_name(ver, subdir)
 
-    releasenotes_note = if isempty(rp.release_notes)
+    releasenotes_note = if releasenotes_source == :invoke
+        ""
+    elseif releasenotes_source == :changelog
+        """
+        ### Release Notes
+
+        The following release notes were found for the given version from a CHANGELOG/NEWS/HISTORY.md file.
+        To provide custom release notes invoke with text headed by `Release notes:`
+
+        ```
+        $release_notes
+        ```
+
+        """
+    elseif releasenotes_source == :none
         """
 
         ### Tip: Release Notes
@@ -120,8 +144,6 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
         To add them here just re-invoke and the PR will be updated.
 
         """
-    else
-        ""
     end
 
     cbody = """

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -109,7 +109,7 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
         i.e.
         ```
-        @JuliaRegistrator register()
+        @JuliaReg... register()
 
         Release notes:
 

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -97,10 +97,25 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
 
     pr, msg = create_or_find_pull_request(repo, params, rbrn)
     tag = tag_name(ver, subdir)
-
+    
+    releasenotes_note if isempty(rp.release_notes)
+        """
+        
+        ### Tip: Release Notes
+        
+        Did you know you can add release notes too? Just add markdown formatted text underneath the comment and it will be added to 
+        the registry PR, and if tagbot is installed it will also be added to the tag created on this repository.
+        
+        """
+    else
+        ""
+    end
+    
     cbody = """
         Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
-
+        $(releasenotes_note)
+        ### Tagging
+    
         After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.
 
         This will be done automatically if the [Julia TagBot GitHub Action](https://github.com/marketplace/actions/julia-tagbot) is installed, or can be done manually through the github interface, or via:


### PR DESCRIPTION
Builds on #360 

Tries to find release notes from a CHANGELOG/NEWS/HISTORY.md file.

The best strategy for parsing the changelog file isn't clear to me. 
I think it should be flexible enough to support most formats, but needs to not be tripped up by things like version numbers in the body text.

cc. @GunnarFarneback 