### PR TITLE
put release notes in a code block to avoid automatic PR links being wrong

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using Registrator
 makedocs(
     modules = [Registrator],
     sitename = "Registrator.jl",
+    warnonly = :missing_docs,
     pages = [
         "Home" => "index.md",
         "Hosting Your Own" => "hosting.md",

--- a/src/pull_request.jl
+++ b/src/pull_request.jl
@@ -38,7 +38,9 @@ function pull_request_contents(;
         lines,
         "- Release notes:",
         "<!-- BEGIN RELEASE NOTES -->",
-        join(map(line -> "> $line", split(release_notes, "\n")), "\n"),
+        "```",
+        release_notes,
+        "```",
         "<!-- END RELEASE NOTES -->",
         ""
     )

--- a/src/pull_request.jl
+++ b/src/pull_request.jl
@@ -38,9 +38,9 @@ function pull_request_contents(;
         lines,
         "- Release notes:",
         "<!-- BEGIN RELEASE NOTES -->",
-        "```",
+        "`````",
         release_notes,
-        "```",
+        "`````",
         "<!-- END RELEASE NOTES -->",
         ""
     )


### PR DESCRIPTION
Otherwise `#12345` was being expanded to General PRs not PRs on the origin repo.

The many backticks allows this to work:

`````
```
hello
```

````
world
````
`````