### PR TITLE
Don't use the `exception=get_backtrace(...)` pattern

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -210,8 +210,8 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
             set_error_status(rp)
         end
     catch ex
-        bt = get_backtrace(ex)
-        @info("Unexpected error: $bt")
+        @info "Unexpected error" exception = (ex, catch_backtrace())
+        bt = sprint(Base.showerror, ex, catch_backtrace())
         raise_issue(rp.evt, rp.phrase, bt)
     end
     @info("Done processing register event", reponame=rp.reponame, target_registry_name)

--- a/src/commentbot/approval.jl
+++ b/src/commentbot/approval.jl
@@ -25,7 +25,7 @@ function get_metadata_from_pr_body(rp::RequestParams, auth)
         meta = String(decrypt(MbedTLS.CIPHER_AES_128_CBC, key, hex2bytes(enc_meta), key))
         return JSON.parse(meta)
     catch ex
-        @debug("Exception occured while parsing PR body", get_backtrace(ex))
+        @debug "Exception occured while parsing PR body" exception = (ex, catch_backtrace())
     end
 
     nothing
@@ -140,8 +140,8 @@ function action(rp::RequestParams{ApprovalTrigger}, zsock)
             make_comment(rp.evt, "Error in approval process: $err")
         end
     catch ex
-        bt = get_backtrace(ex)
-        @info("Unexpected error: $bt")
+        @info "Unexpected error" exception = (ex, catch_backtrace())
+        bt = sprint(Base.showerror, ex, catch_backtrace())
         raise_issue(rp.evt, rp.phrase, bt)
     end
     @info("Done processing approval event", reponame=rp.reponame, rp.trigger_src.prid)

--- a/src/management.jl
+++ b/src/management.jl
@@ -1,5 +1,3 @@
-get_backtrace(ex) = sprint(Base.showerror, ex, catch_backtrace())
-
 function get_log_level(l)
     log_level_str = lowercase(l)
 
@@ -64,7 +62,7 @@ function recover(
                 @warn("Stopping", name)
                 return
             else # exception_action == :continue
-                @error("Recovering from unknown exception", name, backoff, exception=get_backtrace(ex))
+                @error "Recovering from unknown exception" name backoff exception = (ex, catch_backtrace())
                 sleep(backoff)
                 backoff = min(backoffmax, backoff+backoffincrement)
             end

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -248,7 +248,7 @@ function gettreesha(
             readchomp(`git -C $dest rev-parse $ref:$subdir`), ""
         end
     catch ex
-        @error("Exception while getting tree SHA", exception=get_backtrace(ex))
+        @error "Exception while getting tree SHA" exception=(ex, catch_backtrace())
         nothing, "Exception while getting tree SHA"
     end
 end

--- a/src/webui/routes/register.jl
+++ b/src/webui/routes/register.jl
@@ -42,7 +42,7 @@ function register(r::HTTP.Request)
     project = try
         RegistryTools.Project(TOML.parse(IOBuffer(toml)))
     catch e
-        @error "Reading project from (Julia)Project.toml failed" exception=get_backtrace(e)
+        @error "Reading project from (Julia)Project.toml failed" exception=(e, catch_backtrace())
         return json(400; error="(Julia)Project.toml is invalid")
     end
     for k in [:name, :uuid, :version]


### PR DESCRIPTION
It makes the stacktraces from the error handlers pretty much useless and hinders debugging. In particular, since `exception` is now just a string, the logging macros will elide most of the stacktrace. As an MWE:

```
julia> try
       error("1234")
       catch e
       @error "Error handler" exception = sprint(Base.showerror, e, catch_backtrace())
       end
┌ Error: Error handler
│   exception = "1234\nStacktrace:\n  [1] error(s::String)\n    @ Base ./error.jl:35\n  [2] top-level scope\n    @ REPL[9]:2\n  [3] eval\n    @ ./boot.jl:370 [inlined]\n  [4] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)\n    @ REPL ~/.julia/juliaup/julia-1.9" ⋯ 974 bytes ⋯ "816 [inlined]\n [12] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)\n    @ Base ./client.jl:405\n [13] exec_options(opts::Base.JLOptions)\n    @ Base ./client.jl:322\n [14] _start()\n    @ Base ./client.jl:522"
└ @ Main REPL[9]:4
```

Instead I suggest using the standard `exception = (e, catch_backtrace())` pattern.