### PR TITLE
fix: create github pull request for forked registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.9.1"
+version = "1.9.2"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -324,11 +324,12 @@ function make_registration_request(
     owner = r.repo.owner.login
     repo = r.repo.name
     base = r.repo.default_branch
-    head = string(REGISTRY[].fork_repo.owner.login, ":", branch)
+    fork_owner = REGISTRY[].fork_repo.owner.login
+    head = owner == fork_owner ? branch : string(fork_owner, ":", branch)
     try
         result, _ = create_pull_request(
             r.forge, owner, repo;
-            head=branch,
+            head=head,
             base=base,
             title=title,
             body=body,
@@ -341,11 +342,11 @@ function make_registration_request(
         end
 
         if !exists
-            @error "An error occurred when creating pull request" owner=owner repo=repo base=base head=branch exception=ex,catch_backtrace()
+            @error "An error occurred when creating pull request" owner=owner repo=repo base=base head=head exception=ex,catch_backtrace()
             return nothing, nothing
         end
 
-        val, _ = get_pull_requests(r.forge, owner, repo; head="$owner:$branch", base=base, state="open")
+        val, _ = get_pull_requests(r.forge, owner, repo; head=head, base=base, state="open")
 
         if length(val) != 1
             @error "Expected to find one open pull request created from a previous registration attempt but got $(length(val)) pull requests" owner=owner repo=repo base=base head=branch exception=ex,catch_backtrace()


### PR DESCRIPTION
Originally added in #358 this was broken in #392. Setting `head` back to `fork_owner:branch` in this PR.