### PR TITLE
fix: head is incorrect for get_pull_requests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.9.2"
+version = "1.9.3"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -325,7 +325,7 @@ function make_registration_request(
     repo = r.repo.name
     base = r.repo.default_branch
     fork_owner = REGISTRY[].fork_repo.owner.login
-    head = owner == fork_owner ? branch : string(fork_owner, ":", branch)
+    head = string(fork_owner, ":", branch)
     try
         result, _ = create_pull_request(
             r.forge, owner, repo;
@@ -349,7 +349,7 @@ function make_registration_request(
         val, _ = get_pull_requests(r.forge, owner, repo; head=head, base=base, state="open")
 
         if length(val) != 1
-            @error "Expected to find one open pull request created from a previous registration attempt but got $(length(val)) pull requests" owner=owner repo=repo base=base head=branch exception=ex,catch_backtrace()
+            @error "Expected to find one open pull request created from a previous registration attempt but got $(length(val)) pull requests" owner=owner repo=repo base=base head=head exception=ex,catch_backtrace()
             return nothing, nothing
         end
 


### PR DESCRIPTION
Broken by #431. `get_pull_requests` requires head to be mentioned in the format `$owner:$branch` always.

With just `branch` it retrieves all pull requests, Example:
```
Error: Expected to find one open pull request created from a previous registration attempt but got 30 pull requests
```