### PR TITLE
feat: use GIT_ASKPASS with git clone so tokens do not appear in log messages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.9.3"
+version = "1.9.4"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"


### PR DESCRIPTION
use GIT_ASKPASS to hide token from log messages