### PR TITLE
safer `withpasswd` method

### DIFF
--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -269,14 +269,17 @@ function withpasswd(func, url::URI)
     local user, passwd = split(info, ":")
     local newurl = URI(replace(string(url), "$info@" => ""))
     mktemp() do path, io
+        # base64 encode now and decode while printing out in shell to avoid shell injection
+        encoded_user = base64encode(user)
+        encoded_passwd = base64encode(passwd)    
         print(io, """
 #!/bin/sh
 case "\$1" in
     Username*)
-        echo "$user"
+        echo  "\$(echo "$encoded_user" | base64 -d)"
         ;;
     Password*)
-        echo "$passwd"
+        echo "\$(echo "$encoded_passwd" | base64 -d)"
         ;;
 esac
 """)

--- a/test/webui/gitutils.jl
+++ b/test/webui/gitutils.jl
@@ -17,6 +17,19 @@ restoreconfig!()
     @test isauthorized("username", "reponame") == AuthFailure("Unkown user type or repo type")
     mock_provider!()
 
+    Registrator.WebUI.withpasswd("https://foo:bar\">&baz@github.com/owner/repo") do newurl,envs
+        askpass=envs[1]
+        script=split(askpass, '=')[2]
+    
+        # run script and ask it to print out username
+        username = strip(read(Cmd(String["sh", script, "Username"]), String))
+        @test username == "foo"
+    
+        # run script and ask it to print out password
+        password = strip(read(Cmd(String["sh", script, "Password"]), String))
+        @test password == "bar\">&baz"
+    end
+
     @testset "GitHub" begin
         user = GitHub.User(login="user123")
         org = GitHub.User(login="JuliaLang")


### PR DESCRIPTION
The `withpasswd` method executes a shell script with dynamic variables interpolated. The values could sometimes contain characters that may break script syntax. Those could, depending on how an application is using the APIs, also be coming from user inputs, so they can be unpredictable. This change is to interpolate the base64 values of the variables which would be safe and then pipe it to base64 decode utility at runtime to print out the unencoded string. Also added a test.

This brings in additional dependency on the `base64` utility though, which is probably not too bad.