### PR TITLE
fix return value of gittreesha

### DIFF
--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -262,7 +262,7 @@ function gettreesha(
                 run(Cmd(Cmd(String["git", "clone", "--bare", string(url), dest]); env))
             end
             # let Cmd interpolate strings safely
-            readchomp(Cmd(String["git", "-C", dest, "rev-parse", "$ref:$subdir"]))
+            readchomp(Cmd(String["git", "-C", dest, "rev-parse", "$ref:$subdir"])), ""
         end
     catch ex
         @error "Exception while getting tree SHA" exception=(ex, catch_backtrace())

--- a/test/webui/gitutils.jl
+++ b/test/webui/gitutils.jl
@@ -17,10 +17,11 @@ restoreconfig!()
     org = GitHub.User(login="JuliaLang")
 
     public_repo_of_org = GitHub.Repo(name="Example.jl", private=false, owner=org, organization=org, permissions = GitHub.Permissions(admin = true, push = false, pull = true), clone_url="https://github.com/JuliaLang/Example.jl.git")
-    example_master_treesha = Base.redirect_stderr(devnull) do
+    example_master_treesha, err = Base.redirect_stderr(devnull) do
         Registrator.WebUI.gettreesha(public_repo_of_org, "master", "")
     end
     @test length(example_master_treesha) == 40
+    @test err == ""
 
     ret, err = Base.redirect_stderr(devnull) do
         Registrator.WebUI.gettreesha(public_repo_of_org, "mas ter", "")


### PR DESCRIPTION
`gittreesha` should return a tuple of the sha and error message. A bug introduced in #449 returned only the sha when there was no error. This fixes the bug and also updates the tests