### PR TITLE
Add Codeberg support to the Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ There are two ways to use Registrator: a web interface and a GitHub app.
 
 ### Via the Web Interface
 
-This workflow supports repositories hosted on either GitHub or GitLab.
+This workflow supports repositories hosted on GitHub, GitLab, or Codeberg.
 
-Go to https://juliahub.com and log in using your GitHub or GitLab account. Then click on "Register packages" on the left menu.
+Go to https://juliahub.com and log in using your GitHub, GitLab, or Codeberg account. Then click on "Register packages" on the left menu.
 There are also more detailed instructions [here](https://juliaregistries.github.io/Registrator.jl/stable/webui/#Usage-(For-Package-Maintainers)-1).
 
 ### Via the GitHub App

--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -25,8 +25,8 @@ It should contain at least three keys:
 Once you've prepared your repository, using Registrator is simple.
 
 1. The first thing to do is to identify yourself as someone who can register your package.
-   At the homepage of the site, you'll be greeted by links to log in to either GitHub or GitLab.
-   If you're registering a GitHub package, then log into GitHub, and likewise for GitLab.
+   At the homepage of the site, you'll be greeted by links to log in with GitHub, GitLab, or Codeberg.
+   Log in with the provider that hosts your package repository.
 
 2. Once authenticated, you'll see a text box to input the URL to your package repository.
    Do so, then press "Submit".
@@ -45,7 +45,7 @@ This section is for people who want to host an instance of Registrator for their
 ### Provider Setup
 
 Here, the term `$PROVIDER` indicates the provider of your registry repository.
-In most cases, that will be GitHub, or perhaps GitLab.
+In most cases, that will be GitHub, GitLab, or Codeberg.
 
 You will need:
 
@@ -53,13 +53,13 @@ You will need:
 - A `$PROVIDER` user: This user must have permissions to push to the registry and create pull requests.
 - A `$PROVIDER` API key: This should be created in the user's account.
 
-The OAuth providers currently supported are GitHub and GitLab.
-You can choose to support one or both (or none, but that wouldn't be very useful).
+The OAuth providers currently supported are GitHub, GitLab, and Codeberg.
+You can choose to support any subset of them (or none, but that wouldn't be very useful).
 
 For each provider that you support, you will need:
 
 - An OAuth2 application: For letting users authenticate.
-  When setting the callback URL, use `$SERVER_URL/callback?provider=(github|gitlab)`.
+  When setting the callback URL, use `$SERVER_URL/callback?provider=(github|gitlab|codeberg)`.
   The value for `$SERVER_URL` is covered below.
   GitLab will ask you what scopes you want at application creation time, you want `read_user`.
 - A user and API key: This can be the same as you created above for `$PROVIDER`.
@@ -97,8 +97,8 @@ It's important to note that optional values **must** be omitted or commented out
 - `extra_providers`: Path to a Julia file that adds extra providers.
   This should only be used for certain cases when your provider is self-hosted (see next section).
 - `registry_provider`: The registry provider, which is usually inferred from the registry URL.
-  You should only set this if provider is one you added yourself or has a URL that does not contain `github` or `gitlab`.
-  For GitHub, the value should be `github`, and for GitLab, it should be `gitlab`.
+  You should only set this if provider is one you added yourself or has a URL that does not contain `github`, `gitlab`, or `codeberg`.
+  For GitHub, the value should be `github`, for GitLab it should be `gitlab`, and for Codeberg it should be `codeberg`.
   For any other provider, it should be whatever key you used in your extra providers file.
 - `registry_deps`: A list of URLs representing any registries that your target registry depends on.
 - `disable_release_notes`: Set to `true` to disable the release notes text box.
@@ -109,10 +109,10 @@ It's important to note that optional values **must** be omitted or commented out
 - `allow_private`: Set this to `true` if you want to register private packages. Default is `false`.
 - `enable_logging`: Set this to `false` if you want to use a custom logger in your Julia code. By default a `SimpleLogger` is used that writes to `stdout`.
 
-#### `[web.git{hub,lab}]` Section
+#### `[web.{github,gitlab,codeberg,bitbucket}]` Sections
 
 If you want to disable a provider, simply omit its section.
-For example, to support GitHub packages but not GitLab packages, only provide a `[web.github]` section.
+For example, to support GitHub packages but not GitLab or Codeberg packages, only provide a `[web.github]` section.
 
 ##### Required
 
@@ -126,16 +126,18 @@ For example, to support GitHub packages but not GitLab packages, only provide a 
   You should only set this variable if your provider is self-hosted (i.e. with a non-default URL).
 - `auth_url`: OAuth2 authentication URL.
   Only set this for self-hosted providers.
-- `token_url`: OAuth2 token exchange URL.p
+- `token_url`: OAuth2 token exchange URL.
   Only set this for self-hosted providers.
 - `disable_rate_limits`: Set to `true` to disable rate limit processing.
   Only set this for self-hosted instances that don't use rate limiting.
+- `scope`: OAuth scope override.
+  In most cases you should leave this alone and use the provider default.
+  For Codeberg, the default is `read:user`.
 
 ### Adding Extra Providers
 
 In almost all cases, you shouldn't need to do this.
-The only real use case is when your registry is on a self-hosted GitHub or GitLab instance, and you also want to allow registering of packages from the public instance of that provider.
-The only two providers supported are GitHub and GitLab.
+The only real use case is when your registry is on a self-hosted GitHub, GitLab, or Forgejo instance, and you also want to allow registering packages from the public instance of that provider.
 If you do want to do this, then you should set `web.extra_providers` as mentioned above.
 The file should look like this:
 
@@ -171,9 +173,9 @@ PROVIDERS["mygitlab"] = Provider(;
 
 - `name`: The text displayed on the authentication link.
 - `client`: A [GitForge](https://cdg.dev/GitForge.jl/stable) `Forge` with access to your provider.
-- `scope`: Use `public_repo` for GitHub and `read_user` for GitLab.
-- `include_state`: Leave out for GitHub and set `false` for GitLab.
-- `token_type`: Leave out for GitHub and set `OAuth2Token` for GitLab.
+- `scope`: Use `public_repo` for GitHub, `read_user` for GitLab, and `read:user` for Codeberg.
+- `include_state`: Leave out for GitHub and Codeberg, and set `false` for GitLab.
+- `token_type`: Leave out for GitHub and Codeberg, and set `OAuth2Token` for GitLab.
 
 The OAuth2 application info and URLs are covered above.
 When setting your OAuth2 application's callback URL, make sure that it ends with `?provider=$PROVIDER`, where `$PROVIDER` is `mygithub` for the GitHub example above.
@@ -194,7 +196,7 @@ It's not important to keep it intact, as it is synchronized before registering a
 
 ### Basic Recipe: Public Registry
 
-Here's a general case of hosting a registry on GitHub and allowing package registrations from both GitHub and GitLab.
+Here's a general case of hosting a registry on GitHub and allowing package registrations from GitHub, GitLab, and Codeberg.
 The registry will be owned by `RegistryOwner` and the name will be `MyRegistry`.
 The web server will be hosted at `https://myregistrator.com`, and run on port 4000.
 
@@ -211,7 +213,7 @@ server_url = "https://myregistrator.com"
 registry_url = "https://github.com/RegistryOwner/MyRegistry"
 ```
 
-Next, we create the GitHub and GitLab users and API keys, and save those API keys:
+Next, we create the GitHub, GitLab, and Codeberg users and API keys, and save those API keys:
 
 ```toml
 [web.github]
@@ -219,10 +221,13 @@ token = "abc..."
 
 [web.gitlab]
 token = "abc..."
+
+[web.codeberg]
+token = "abc..."
 ```
 
-Next, create OAuth2 applications for both of them.
-The callback URLs will be `https://myregistrator.com/callback?provider=github` and `https://myregistrator.com/callback?provider=gitlab`.
+Next, create OAuth2 applications for all of them.
+The callback URLs will be `https://myregistrator.com/callback?provider=github`, `https://myregistrator.com/callback?provider=gitlab`, and `https://myregistrator.com/callback?provider=codeberg`.
 Add the client IDs and secrets to our file:
 
 ```toml
@@ -231,6 +236,10 @@ client_id = "abc..."
 client_secret = "abc..."
 
 [web.gitlab]
+client_id = "abc..."
+client_secret = "abc..."
+
+[web.codeberg]
 client_id = "abc..."
 client_secret = "abc..."
 ```
@@ -270,6 +279,11 @@ client_id = "abc..."
 client_secret = "abc..."
 
 [web.gitlab]
+token = "abc..."
+client_id = "abc..."
+client_secret = "abc..."
+
+[web.codeberg]
 token = "abc..."
 client_id = "abc..."
 client_secret = "abc..."

--- a/run/config.web.toml
+++ b/run/config.web.toml
@@ -40,6 +40,16 @@ client_secret = ""
 # token_url = ""
 # disable_rate_limits = false
 
+[web.codeberg]
+token = ""
+client_id = ""
+client_secret = ""
+# api_url = ""
+# auth_url = ""
+# token_url = ""
+# scope = "read:user"
+# disable_rate_limits = false
+
 [web.bitbucket]
 # FORMAT: "USER:KEY" -- USER is the Bitbucket account, KEY is a Bitbucket "app password"
 token = ""

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -4,7 +4,7 @@ using ..Registrator: pull_request_contents, tag_name
 import RegistryTools
 
 using Dates
-using GitForge, GitForge.GitHub, GitForge.GitLab, GitForge.Bitbucket
+using GitForge, GitForge.GitHub, GitForge.GitLab, GitForge.Bitbucket, GitForge.Forgejo
 using Base64
 using HTTP
 using JSON
@@ -78,8 +78,8 @@ end
 struct RegistrationData
     project::RegistryTools.Project
     tree::String
-    repo::Union{GitHub.Repo, GitLab.Project, Bitbucket.Repo}
-    user::Union{GitHub.User, GitLab.User, Bitbucket.User}
+    repo::Union{GitHub.Repo, GitLab.Project, Bitbucket.Repo, Forgejo.Repo}
+    user::Union{GitHub.User, GitLab.User, Bitbucket.User, Forgejo.User}
     ref::String
     commit::String
     notes::String
@@ -121,6 +121,7 @@ include("routes/bitbucket.jl")
 auth_href(::Provider{GitLabAPI}) = "$(ROUTES[:AUTH])?provider=gitlab"
 auth_href(::Provider{GitHubAPI}) = "$(ROUTES[:AUTH])?provider=github"
 auth_href(::Provider{BitbucketAPI}) = "$(ROUTES[:BITBUCKET])/auth"
+auth_href(::Provider{ForgejoAPI}) = "$(ROUTES[:AUTH])?provider=codeberg"
 
 ##############
 # Entrypoint #
@@ -131,6 +132,8 @@ function init_registry()
     k = get(CONFIG, "registry_provider") do
         if occursin("github", url)
             "github"
+        elseif occursin("codeberg", url)
+            "codeberg"
         elseif occursin("bitbucket", url)
             "bitbucket"
         else

--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -4,10 +4,12 @@ using Mocking
 config(::GitHub.Repo) = CONFIG["github"]
 config(::GitLab.Project) = CONFIG["gitlab"]
 config(::Bitbucket.Repo) = CONFIG["bitbucket"]
+config(::Forgejo.Repo) = CONFIG["codeberg"]
 
 provider(::Union{GitHubAPI, GitHub.Repo}) = PROVIDERS["github"]
 provider(::Union{GitLabAPI, GitLab.Project}) = PROVIDERS["gitlab"]
 provider(::Union{BitbucketAPI, Bitbucket.Repo}) = PROVIDERS["bitbucket"]
+provider(::Union{ForgejoAPI, Forgejo.Repo}) = PROVIDERS["codeberg"]
 
 # # Run some GitForge function, warning on error but still returning the value.
 macro gf(ex::Expr)
@@ -157,6 +159,32 @@ function isauthorized(u::User{Bitbucket.User}, repo::Bitbucket.Repo, fetch = tru
     AuthFailure("User $(u.user.nickname) is not a member of the workspace $(repo.workspace.slug) or a collaborator on repo $(repo.slug)")
 end
 
+function isauthorized(u::User{Forgejo.User}, repo::Forgejo.Repo, fetch = true)
+    !get(CONFIG, "allow_private", false) && repo.private &&
+        return AuthFailure("Repo $(repo.name) is private")
+    fjforge = provider(repo).client
+    refreshed = false
+    if fetch
+        newrepo = @gf @mock get_repo(u.forge, repo.owner.login, repo.name)
+        if newrepo !== nothing
+            repo = newrepo
+            refreshed = true
+        end
+    end
+    # Only trust per-user permissions if they came from the user's authenticated connection.
+    refreshed && repo !== nothing && repo.permissions !== nothing && repo.permissions.push &&
+        return AuthSuccess()
+    ((@gf_bool @mock is_collaborator(u.forge, repo.owner.login, repo.name, u.user.login)) ||
+        (@gf_bool @mock is_collaborator(fjforge, repo.owner.login, repo.name, u.user.login))) &&
+        return AuthSuccess()
+    repo.owner.login == u.user.login &&
+        return AuthSuccess()
+    ((@gf_bool @mock is_member(u.forge, repo.owner.login, u.user.login)) ||
+        (@gf_bool @mock is_member(fjforge, repo.owner.login, u.user.login))) &&
+        return AuthSuccess()
+    AuthFailure("User $(u.user.login) is not a collaborator on repository $(repo.name) and does not appear to be a member of the owning account $(repo.owner.login)")
+end
+
 # Get the raw (Julia)Project.toml text from a repository.
 function gettoml(::GitHubAPI, repo::GitHub.Repo, ref::AbstractString, subdir::AbstractString)
     forge = provider(repo).client
@@ -205,6 +233,21 @@ function gettoml(::BitbucketAPI, repo::Bitbucket.Repo, ref::AbstractString, subd
     return nothing
 end
 
+function gettoml(::ForgejoAPI, repo::Forgejo.Repo, ref::AbstractString, subdir::AbstractString)
+    forge = provider(repo).client
+    lasterr = nothing
+    for file in Base.project_names
+        try
+            fc, _ = get_file_contents(forge, repo.owner.login, repo.name, joinpath(subdir, file); ref=ref)
+            return decodeb64(fc.content)
+        catch err
+            lasterr = (err, catch_backtrace())
+        end
+    end
+    @error "Failed to get project file" exception=lasterr
+    return nothing
+end
+
 function getcommithash(::GitHubAPI, repo::GitHub.Repo, ref::AbstractString)
     forge = provider(repo).client
     commit = @gf get_commit(forge, repo.owner.login, repo.name, ref)
@@ -221,6 +264,12 @@ function getcommithash(::BitbucketAPI, repo::Bitbucket.Repo, ref::AbstractString
     bbforge = provider(repo).client
     commit = @gf get_commit(bbforge, repo.workspace.slug, repo.slug, ref)
     return commit === nothing ? nothing : commit.hash
+end
+
+function getcommithash(::ForgejoAPI, repo::Forgejo.Repo, ref::AbstractString)
+    forge = provider(repo).client
+    commit = @gf get_commit(forge, repo.owner.login, repo.name, ref)
+    return commit === nothing ? nothing : commit.sha
 end
 
 # Get a repo's clone URL.
@@ -244,9 +293,15 @@ function cloneurl(r::Bitbucket.Repo, is_ssh::Bool=false)
     token = config(r)["token"]
     string(URI(URI(link[1]["href"]); userinfo=token))
 end
+function cloneurl(r::Forgejo.Repo, is_ssh::Bool=false)
+    url = is_ssh ? r.ssh_url : r.clone_url
+    host = URI(url).host
+    token = config(r)["token"]
+    replace(url, host => "oauth2:$token@$host")
+end
 
 function gettreesha(
-    r::Union{GitLab.Project, GitHub.Repo, Bitbucket.Repo},
+    r::Union{GitLab.Project, GitHub.Repo, Bitbucket.Repo, Forgejo.Repo},
     ref::AbstractString,
     subdir::AbstractString
 )
@@ -465,15 +520,18 @@ web_url(pr::Bitbucket.PullRequest) = pr.links.html["href"]
 web_url(u::GitHub.User) = u.html_url
 web_url(u::GitLab.User) = u.web_url
 web_url(u::Bitbucket.User) = u.links.html["href"]
+web_url(u::Forgejo.User) = u.html_url
 web_url(r::GitHub.Repo) = r.html_url
 web_url(r::GitLab.Project) = r.web_url
 web_url(r::Bitbucket.Repo) = r.links.html["href"]
+web_url(r::Forgejo.Repo) = r.html_url
 
 
 # Get a user's @ mention.
 mention(u::GitHub.User) = "$(mention(u.login))"
 mention(u::GitLab.User) = "$(mention(u.username))"
 mention(u::Bitbucket.User) = "$(mention(u.username))"
+mention(u::Forgejo.User) = "$(mention(u.username))"
 
 # Get a user's representation for a registry PR.
 # If the registry is from the same provider, mention the user, otherwise use the URL.
@@ -563,6 +621,34 @@ function istagwrong(
         end
     catch err
         @debug("Could not fetch tags")
+    end
+    false
+end
+
+function istagwrong(
+    ::ForgejoAPI,
+    repo::Forgejo.Repo,
+    tag::AbstractString,
+    commit::AbstractString,
+)
+    result = @gf get_tags(provider(repo).client, repo.owner.login, repo.name)
+
+    if result === nothing
+        @debug("Could not fetch tags")
+        return false
+    end
+
+    for t in result
+        v = t.name
+        if startswith(v, "v")
+            v = v[2:end]
+        end
+        if v == string(tag)
+            if t.commit !== nothing && t.commit.sha != commit
+                return true
+            end
+            break
+        end
     end
     false
 end

--- a/src/webui/providers.jl
+++ b/src/webui/providers.jl
@@ -14,6 +14,7 @@ end
 provider(::Type{GitHubAPI}) = PROVIDERS["github"]
 provider(::Type{GitLabAPI}) = PROVIDERS["gitlab"]
 provider(::Type{BitbucketAPI}) = PROVIDERS["bitbucket"]
+provider(::Type{ForgejoAPI}) = PROVIDERS["codeberg"]
 
 function init_providers()
     if haskey(CONFIG, "github")
@@ -68,6 +69,23 @@ function init_providers()
             token_url=get(bitbucket, "token_url", "https://bitbucket.org/oauth2/access_token"),
             token_type=Bitbucket.JWT,
             scope="repository account",
+        )
+    end
+
+    if haskey(CONFIG, "codeberg")
+        codeberg = CONFIG["codeberg"]
+        PROVIDERS["codeberg"] = Provider(;
+            name="Codeberg",
+            client=ForgejoAPI(;
+                url=get(codeberg, "api_url", Forgejo.DEFAULT_URL),
+                token=Forgejo.Token(codeberg["token"]),
+                has_rate_limits=!get(codeberg, "disable_rate_limits", false),
+            ),
+            client_id=codeberg["client_id"],
+            client_secret=codeberg["client_secret"],
+            auth_url=get(codeberg, "auth_url", "https://codeberg.org/login/oauth/authorize"),
+            token_url=get(codeberg, "token_url", "https://codeberg.org/login/oauth/access_token"),
+            scope=get(codeberg, "scope", "read:user"),
         )
     end
 

--- a/src/webui/routes/auth.jl
+++ b/src/webui/routes/auth.jl
@@ -15,7 +15,9 @@ function auth(r::HTTP.Request)
     state = getcookie(r, "state")
     if !isempty(state) && haskey(USERS, state)
         F = typeof(USERS[state].forge)
-        if pkey == "github" && F === GitHubAPI || pkey == "gitlab" && F === GitLabAPI
+        if pkey == "github" && F === GitHubAPI ||
+           pkey == "gitlab" && F === GitLabAPI ||
+           pkey == "codeberg" && F === ForgejoAPI
             # TODO: This does not support custom providers.
             return HTTP.Response(307, ["Location" => ROUTES[:SELECT]])
         end

--- a/src/webui/routes/callback.jl
+++ b/src/webui/routes/callback.jl
@@ -18,8 +18,12 @@ function callback(r::HTTP.Request)
 
     resp = HTTP.post(
         provider.token_url;
-        headers=["Accept" => "application/json", "User-Agent" => "Registrator.jl"],
-        query=query,
+        headers=[
+            "Accept" => "application/json",
+            "Content-Type" => "application/x-www-form-urlencoded",
+            "User-Agent" => "Registrator.jl",
+        ],
+        body=HTTP.escapeuri(query),
     )
     token = JSON.parse(String(resp.body))["access_token"]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using HTTP: HTTP
 using Sockets: Sockets
 
 using GitForge: GitForge, get_user
-using GitForge: GitForge, GitHub, GitLab, Bitbucket
+using GitForge: GitForge, GitHub, GitLab, Bitbucket, Forgejo
 using GitForge.GitHub: GitHub, GitHubAPI, NoToken, Token
 
 using Registrator: Registrator
@@ -42,6 +42,11 @@ function populate_config!()
         "bitbucket" => Dict{String, Any}(
             "token" => get(ENV, "BITBUCKET_API_TOKEN", ""),
             "workspace" => "wrburdick",
+            "client_id" => "",
+            "client_secret" => "",
+        ),
+        "codeberg" => Dict{String, Any}(
+            "token" => get(ENV, "CODEBERG_TOKEN", ""),
             "client_id" => "",
             "client_secret" => "",
         ),

--- a/test/webui.jl
+++ b/test/webui.jl
@@ -5,15 +5,15 @@ restoreconfig!()
 @testset "Web UI" begin
     @testset "Provider initialization" begin
         UI.init_providers()
-        @test length(UI.PROVIDERS) == 3
-        @test Set(collect(keys(UI.PROVIDERS))) == Set(["github", "gitlab", "bitbucket"])
+        @test length(UI.PROVIDERS) == 4
+        @test Set(collect(keys(UI.PROVIDERS))) == Set(["github", "gitlab", "bitbucket", "codeberg"])
         empty!(UI.PROVIDERS)
 
         delete!(UI.CONFIG, "github")
         delete!(UI.CONFIG, "bitbucket")
         UI.CONFIG["gitlab"]["disable_rate_limits"] = true
         UI.init_providers()
-        @test collect(keys(UI.PROVIDERS)) == ["gitlab"]
+        @test Set(collect(keys(UI.PROVIDERS))) == Set(["gitlab", "codeberg"])
         @test !GitForge.has_rate_limits(UI.PROVIDERS["gitlab"].client, identity)
         empty!(UI.PROVIDERS)
         restoreconfig!()
@@ -76,6 +76,7 @@ restoreconfig!()
         @test occursin(UI.CONFIG["registry_url"], s)
         @test occursin("GitHub", s)
         @test occursin("GitLab", s)
+        @test occursin("Codeberg", s)
 
         # When a provider is disabled, its authentication link should not appear.
         delete!(UI.PROVIDERS, "gitlab")
@@ -84,6 +85,7 @@ restoreconfig!()
         s = String(resp.body)
         @test occursin("GitHub", s)
         @test !occursin("GitLab", s)
+        @test occursin("Codeberg", s)
     end
 
     @testset "Route: /select" begin

--- a/test/webui/gitutils.jl
+++ b/test/webui/gitutils.jl
@@ -208,4 +208,69 @@ end
             end
         end
     end
+
+    @testset "Forgejo" begin
+        user = Forgejo.User(login="user123", username="user123")
+        owner = Forgejo.User(login="owner123", username="owner123")
+        org = Forgejo.User(login="Codeberg", username="Codeberg")
+        private_repo = Forgejo.Repo(name="Example.jl", private=true, owner=user, permissions=Forgejo.Permissions(admin=true, push=false, pull=true))
+        owned_public_repo = Forgejo.Repo(name="OwnedExample.jl", private=false, owner=user, permissions=Forgejo.Permissions(admin=true, push=false, pull=true))
+        public_repo_of_user = Forgejo.Repo(name="Example.jl", private=false, owner=owner, permissions=Forgejo.Permissions(admin=true, push=false, pull=true))
+        public_repo_of_org = Forgejo.Repo(name="Example.jl", private=false, owner=org, permissions=Forgejo.Permissions(admin=true, push=false, pull=true))
+        u = User(user, Forgejo.ForgejoAPI())
+
+        @testset "private repo" begin
+            @test isauthorized(u, private_repo, false) == AuthFailure("Repo Example.jl is private")
+        end
+
+        @testset "public repo of user" begin
+            patch_gitforge(is_collaborator=true) do
+                @test isauthorized(u, public_repo_of_user, false) == AuthSuccess()
+            end
+            patch_gitforge(is_collaborator=false) do
+                @test isauthorized(u, public_repo_of_user, false) == AuthFailure("User user123 is not a collaborator on repository Example.jl and does not appear to be a member of the owning account owner123")
+            end
+        end
+
+        @testset "user-token repo refresh failure" begin
+            refresh_failure = @patch GitForge.get_repo(args...) = error("OAuth repo lookup failed")
+            service_forge = UI.provider(public_repo_of_user).client
+
+            apply([refresh_failure]) do
+                patch_gitforge(is_collaborator=false, is_member=false) do
+                    @test isauthorized(u, owned_public_repo, true) == AuthSuccess()
+                end
+            end
+
+            patches = [
+                refresh_failure
+                @patch GitForge.is_collaborator(args...) = args[1] === service_forge
+                @patch GitForge.is_member(args...) = false
+            ]
+            apply(patches) do
+                @test isauthorized(u, public_repo_of_user, true) == AuthSuccess()
+            end
+
+            apply([refresh_failure]) do
+                patch_gitforge(is_collaborator=false, is_member=false) do
+                    @test isauthorized(u, public_repo_of_user, true) == AuthFailure("User user123 is not a collaborator on repository Example.jl and does not appear to be a member of the owning account owner123")
+                end
+            end
+        end
+
+        @testset "public repo of org" begin
+            patch_gitforge(is_collaborator=true, is_member=true) do
+                @test isauthorized(u, public_repo_of_org, false) == AuthSuccess()
+            end
+            patch_gitforge(is_collaborator=true, is_member=false) do
+                @test isauthorized(u, public_repo_of_org, false) == AuthSuccess()
+            end
+            patch_gitforge(is_collaborator=false, is_member=true) do
+                @test isauthorized(u, public_repo_of_org, false) == AuthSuccess()
+            end
+            patch_gitforge(is_collaborator=false, is_member=false) do
+                @test isauthorized(u, public_repo_of_org, false) == AuthFailure("User user123 is not a collaborator on repository Example.jl and does not appear to be a member of the owning account Codeberg")
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Summary

This PR adds Web UI support for registering packages hosted on Codeberg. It depends on the Forgejo support added in JuliaWeb/GitForge.jl#55.

With this change, Registrator can authenticate with Codeberg, inspect a package repository hosted there, and submit the registration request against the configured registry through the usual Web UI flow.

## Scope

This PR is intentionally limited to the Web UI path.

It does not add comment-triggered registration on Codeberg. The final registry PR workflow is unchanged as well: for `General`, Registrator still opens the registration PR on GitHub.

## What Changed

- added `codeberg` as a built-in Web UI provider
- wired `ForgejoAPI` into the provider, auth, and callback flow
- extended the existing built-in "already authenticated" shortcut in `routes/auth.jl` to include Codeberg
- added Forgejo-specific handling in `gitutils.jl` for authorization checks, project file loading, commit lookup, clone URL construction, web URL rendering, and tag mismatch checks
- extended the Web UI tests to cover the Codeberg / Forgejo path
- updated the Web UI documentation and sample config to include Codeberg

## Why The OAuth Changes Are Needed

Live testing against Codeberg also exposed two places where the existing Web UI assumptions did not hold.

First, the callback token exchange in `src/webui/routes/callback.jl` could not complete successfully with the previous implementation. Registrator was sending the OAuth token exchange parameters in the POST query string. In live testing, Codeberg responded with `400 Bad Request`, `unsupported_grant_type`, and the message `Only refresh_token or authorization_code grant type is supported`, even though the request still included `grant_type=authorization_code`. In practice, moving those parameters into an `application/x-www-form-urlencoded` POST body fixed the callback flow. This is therefore a functional fix, not a stylistic cleanup.

Second, even after OAuth login succeeded, the returned Codeberg OAuth token still could not read repository metadata through `GET /repos/{owner}/{repo}` in the way the existing Web UI authorization path expected. In practice, the user could authenticate successfully, but the subsequent repo refresh step still failed with a `read:repository` error.

That behavior is consistent with the current Forgejo documentation, which explicitly notes that OAuth2 scopes are not yet implemented and distinguishes OAuth2 tokens from scoped personal access tokens:

- https://forgejo.org/docs/latest/user/oauth2-provider/
- https://forgejo.org/docs/latest/user/token-scope/

So the problem here was not that Registrator requested the wrong scope. The issue was that the previous Web UI flow assumed stronger repository-read semantics from a Forgejo OAuth token than the platform currently guarantees.

The Forgejo authorization path is therefore adjusted so the OAuth token is still used to identify the logged-in user, while repository lookup and authorization fallback can continue using the configured server-side Codeberg client when that user-token repo refresh fails. If the user-token refresh succeeds, Registrator still trusts the per-user `permissions.push` fast path. If it fails, Registrator falls back to collaborator, owner, and membership checks instead of rejecting the registration immediately.

This does not change the high-level behavior for the existing built-in providers. Registrator still performs the same callback and token exchange flow against each provider's configured `token_url`; the Codeberg-specific change is that the token exchange parameters are now sent in the request body, and the Forgejo authorization path is able to fall back cleanly when user-token repo refresh is unavailable.

## Validation

- `julia --project=. test/runtests.jl` passes (`120 / 120`)
- the Web UI provider and `gitutils` tests now cover the Codeberg / Forgejo path
- the Codeberg Web UI flow was validated end-to-end against a test registry:
  - Codeberg OAuth login succeeded
  - the Forgejo authorization fallback handled the OAuth token not having `read:repository`
  - the registration request reached `RegService`
  - Registrator created and pushed a registry branch
  - Registrator opened a registry pull request successfully: https://github.com/abcdvvvv/TestRegistry/pull/1
- documentation and sample config were updated to match the implementation

## Related

- Depends on JuliaWeb/GitForge.jl#55
- Refs JuliaRegistries/Registrator.jl#430
- Refs JuliaWeb/GitForge.jl#49

Generated with Codex assistance.
