### PR TITLE
feat(commentbot): use github app token for package repo read operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.12.1"
+version = "1.13.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -37,6 +37,7 @@ Distributed = "1"
 FileWatching = "1"
 GitForge = "0.4.3" # Must be >= 0.4.3, see https://github.com/JuliaRegistries/Registrator.jl/pull/453
 GitHub = "5.7.0"
+GitHubAppTokens = "0.0.3"
 HTTP = "1.10.17" # Must be >= 1.10.17, see https://github.com/JuliaRegistries/Registrator.jl/pull/453
 JSON = "0.20, 0.21"
 LibGit2 = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Registrator"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.12.0"
+version = "1.12.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ TimeToLive = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
+GitHubAppTokens = "065bf76e-ca52-408e-80ac-b2f947d0e344"
 
 [compat]
 AutoHashEquals = "0.2"

--- a/run/config.commentbot.toml
+++ b/run/config.commentbot.toml
@@ -47,6 +47,8 @@ user = ""       # A GitHub user ID, can be same as that set for [regservice]
 email = ""      # The email associated with the above user, this is
                 # required for creating the tag in the approval process. Note that this 
                 # is only needed if you want to enable the approval process.
+token = ""      # An access token for the above user ID, this is
+                # required for pushing the commit to the remote registry
 
 secret = ""     # This is the webhook secret that you configure when
                 # you setup an app in GitHub. See

--- a/run/config.commentbot.toml
+++ b/run/config.commentbot.toml
@@ -47,8 +47,6 @@ user = ""       # A GitHub user ID, can be same as that set for [regservice]
 email = ""      # The email associated with the above user, this is
                 # required for creating the tag in the approval process. Note that this 
                 # is only needed if you want to enable the approval process.
-token = ""      # An access token for the above user ID, this is
-                # required for pushing the commit to the remote registry
 
 secret = ""     # This is the webhook secret that you configure when
                 # you setup an app in GitHub. See

--- a/src/RegService.jl
+++ b/src/RegService.jl
@@ -43,7 +43,7 @@ end
 function main(config::AbstractString=isempty(ARGS) ? "config.toml" : first(ARGS))
     merge!(CONFIG, Pkg.TOML.parsefile(config)["regservice"])
     if get(CONFIG, "enable_logging", true)
-        global_logger(SimpleLogger(stdout, get_log_level(CONFIG["log_level"])))
+        global_logger(ConsoleLogger(stdout, get_log_level(CONFIG["log_level"])))
     end
     zsock = ReplySocket(get(CONFIG, "port", 5555))
 

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -46,8 +46,6 @@ get_trigger_id(rp::RequestParams{PullRequestTrigger}) = rp.trigger_src.prid
 get_trigger_id(rp::RequestParams{IssueTrigger}) = get_prid(rp.evt.payload)
 get_trigger_id(rp::RequestParams{CommitCommentTrigger}) = get_comment_commit_id(rp.evt)
 
-reponame_from_url(url::String) = join(split(url, "/")[end-1:end], "/")
-
 function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBranch, target_registry::Dict{String,Any})
     name = rbrn.name
     ver = rbrn.version
@@ -270,7 +268,7 @@ end
 function main(config::AbstractString=isempty(ARGS) ? "config.toml" : first(ARGS); kwargs...)
     merge!(CONFIG, Pkg.TOML.parsefile(config)["commentbot"])
     if get(CONFIG, "enable_logging", true)
-        global_logger(SimpleLogger(stdout, get_log_level(CONFIG["log_level"])))
+        global_logger(ConsoleLogger(stdout, get_log_level(CONFIG["log_level"])))
     end
     zsock = RequestSocket(get(CONFIG, "backend_port", 5555))
 

--- a/src/commentbot/approval.jl
+++ b/src/commentbot/approval.jl
@@ -32,7 +32,7 @@ function get_metadata_from_pr_body(rp::RequestParams, auth)
 end
 
 function handle_approval(rp::RequestParams{ApprovalTrigger})
-    auth = GitHub.authenticate(get_access_token(rp.evt))
+    auth = get_app_auth(rp.evt)
     d = get_metadata_from_pr_body(rp, auth)
 
     if d === nothing

--- a/src/commentbot/approval.jl
+++ b/src/commentbot/approval.jl
@@ -32,7 +32,7 @@ function get_metadata_from_pr_body(rp::RequestParams, auth)
 end
 
 function handle_approval(rp::RequestParams{ApprovalTrigger})
-    auth = get_access_token(rp.evt)
+    auth = GitHub.authenticate(get_access_token(rp.evt))
     d = get_metadata_from_pr_body(rp, auth)
 
     if d === nothing

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -96,7 +96,7 @@ function make_comment(evt::WebhookEvent, body::AbstractString)
     headers = Dict("private_token" => get_access_token(evt))
     params = Dict("body" => body)
     repo = evt.repository
-    auth = GitHub.authenticate(get_user_auth(repo))
+    auth = GitHub.authenticate(get_access_token(evt))
     if is_commit_comment(evt.payload)
         GitHub.create_comment(repo, get_comment_commit_id(evt),
                               :commit; headers=headers,

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -1,5 +1,7 @@
 using GitHubAppTokens
 
+reponame_from_url(url::String) = join(split(url, "/")[end-1:end], "/")
+
 function register_rights_error(evt, user)
     if is_owned_by_organization(evt)
         org = evt.repository.owner.login
@@ -8,6 +10,8 @@ function register_rights_error(evt, user)
         return "**Register Failed**\n$(mention(user)), it looks like you don't have collaborator status on this repository."
     end
 end
+
+get_jwt_auth() = GitHub.JWTAuth(CONFIG["github"]["app_id"], CONFIG["github"]["priv_pem"])
 
 TOKENS_CTX = Ref{GHAppCtx}()
 function get_tokens_ctx()
@@ -18,23 +22,20 @@ function get_tokens_ctx()
 end
 
 function get_access_token(evt::WebhookEvent)
-    get_access_token(evt.repository.owner, evt.repository.name)
+    get_access_token(evt.repository.owner.login, evt.repository.name)
 end
 function get_access_token(namespace::AbstractString, name::AbstractString)
     get_token_for_repo(get_tokens_ctx(), namespace, name)
 end
-function get_user_auth(namespace::AbstractString, name::AbstractString)
-    GitHub.authenticate(get_access_token(namespace, name))
+function get_access_token(repo::AbstractString)
+    namespace, name = split(reponame_from_url(repo), "/")
+    get_access_token(namespace, name)
 end
-function get_user_auth(repo::AbstractString)
-    namespace, name = split(repo, "/")
-    get_user_auth(namespace, name)
-end
-function get_user_auth(repo::GitHub.Repo)
-    get_user_auth(repo.owner, repo.name)
+function get_access_token(repo::GitHub.Repo)
+    get_access_token(repo.owner, repo.name)
 end
 
-function get_sha_from_branch(reponame, brn; auth = GitHub.AnonymousAuth())
+function get_sha_from_branch(reponame, brn, auth)
     try
         b = branch(reponame, Branch(brn); auth=auth)
         sha = b.sha !== nothing ? b.sha : b.commit.sha
@@ -57,7 +58,7 @@ function is_comment_by_collaborator(event)
     @debug("Checking if comment is by collaborator")
     user = get_user_login(event.payload)
     user == "github-actions[bot]" && return true
-    return iscollaborator(event.repository, user; auth=get_access_token(event))
+    return iscollaborator(event.repository, user; auth=GitHub.authenticate(get_access_token(event)))
 end
 
 function is_comment_by_org_owner_or_member(event)
@@ -135,7 +136,7 @@ function set_status(rp, state, desc)
                        "context" => CONFIG["github"]["user"],
                        "description" => desc)
          GitHub.create_status(repo, commit;
-                              auth=get_access_token(rp.evt),
+                              auth=GitHub.authenticate(get_access_token(rp.evt)),
                               params=params)
      end
 end
@@ -200,7 +201,7 @@ function create_or_find_pull_request(
 )
     pr = nothing
     msg = ""
-    auth = get_user_auth(repo)
+    auth = GitHub.authenticate(get_access_token(repo))
     try
         pr = create_pull_request(repo; auth=auth, params=params)
         msg = "created"

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -22,23 +22,20 @@ function get_tokens_ctx()
     TOKENS_CTX[]
 end
 
-function get_access_token(evt::WebhookEvent)
-    get_access_token(evt.repository.owner.login, evt.repository.name)
-end
-function get_access_token(namespace::AbstractString, name::AbstractString)
-    get_token_for_repo(get_tokens_ctx(), namespace, name)
-end
-function get_access_token(repo::AbstractString)
-    namespace, name = split(reponame_from_url(repo), "/")
-    get_access_token(namespace, name)
-end
-function get_access_token(repo::GitHub.Repo)
-    get_access_token(repo.owner, repo.name)
-end
+"""
+Generates an access token for the GitHub app. The token only has access to the WebhookEvent's source repository.
+"""
+get_access_token(evt::WebhookEvent) = get_token_for_repo(get_tokens_ctx(), evt.repository.owner.login, evt.repository.name)
 
-function get_registry_token()
-    return CONFIG["github"]["token"]
-end
+"""
+Use this method to authenticate as GitHub App for package operations
+"""
+get_app_auth(evt::WebhookEvent) = GitHub.authenticate(get_access_token(evt))
+
+"""
+Use this method to authenticate as Bot account for registry operations
+"""
+get_registry_auth() = GitHub.authenticate(CONFIG["github"]["token"])
 
 function get_sha_from_branch(reponame, brn, auth)
     try
@@ -63,7 +60,7 @@ function is_comment_by_collaborator(event)
     @debug("Checking if comment is by collaborator")
     user = get_user_login(event.payload)
     user == "github-actions[bot]" && return true
-    return iscollaborator(event.repository, user; auth=GitHub.authenticate(get_access_token(event)))
+    return iscollaborator(event.repository, user; auth=get_app_auth(event))
 end
 
 function is_comment_by_org_owner_or_member(event)
@@ -72,7 +69,7 @@ function is_comment_by_org_owner_or_member(event)
     user = get_user_login(event.payload)
     user == "github-actions[bot]" && return true
     if get(CONFIG, "check_private_membership", false)
-        return GitHub.check_membership(org, user; auth=GitHub.authenticate(get_access_token(event)))
+        return GitHub.check_membership(org, user; auth=get_app_auth(event))
     else
         return GitHub.check_membership(org, user; public_only=true)
     end
@@ -102,7 +99,7 @@ function make_comment(evt::WebhookEvent, body::AbstractString)
     headers = Dict("private_token" => get_access_token(evt))
     params = Dict("body" => body)
     repo = evt.repository
-    auth = GitHub.authenticate(get_access_token(evt))
+    auth = get_app_auth(evt)
     if is_commit_comment(evt.payload)
         GitHub.create_comment(repo, get_comment_commit_id(evt),
                               :commit; headers=headers,
@@ -141,7 +138,7 @@ function set_status(rp, state, desc)
                        "context" => CONFIG["github"]["user"],
                        "description" => desc)
          GitHub.create_status(repo, commit;
-                              auth=GitHub.authenticate(get_access_token(rp.evt)),
+                              auth=get_app_auth(rp.evt),
                               params=params)
      end
 end
@@ -206,7 +203,7 @@ function create_or_find_pull_request(
 )
     pr = nothing
     msg = ""
-    auth = GitHub.authenticate(get_registry_token())
+    auth = get_registry_auth()
     try
         pr = create_pull_request(repo; auth=auth, params=params)
         msg = "created"

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -9,9 +9,9 @@ function register_rights_error(evt, user)
     end
 end
 
-TOKENS_CTX = Ref{GHAppCtx}(nothing)
+TOKENS_CTX = Ref{GHAppCtx}()
 function get_tokens_ctx()
-    if TOKENS_CTX[] === nothing
+    if !isassigned(TOKENS_CTX)
         TOKENS_CTX[] = GHAppCtx(CONFIG["github"]["app_id"], CONFIG["github"]["priv_pem"])
     end
     TOKENS_CTX[]

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -1,6 +1,7 @@
 using GitHubAppTokens
+using HTTP.URIs: URI
 
-reponame_from_url(url::String) = join(split(url, "/")[end-1:end], "/")
+reponame_from_url(url::String) = join(split(URI(url).path, "/")[end-1:end], "/")
 
 function register_rights_error(evt, user)
     if is_owned_by_organization(evt)
@@ -25,6 +26,7 @@ function get_access_token(evt::WebhookEvent)
     get_access_token(evt.repository.owner.login, evt.repository.name)
 end
 function get_access_token(namespace::AbstractString, name::AbstractString)
+    @info "params = ", namespace, name
     get_token_for_repo(get_tokens_ctx(), namespace, name)
 end
 function get_access_token(repo::AbstractString)
@@ -203,6 +205,7 @@ function create_or_find_pull_request(
     msg = ""
     auth = GitHub.authenticate(get_access_token(repo))
     try
+        @info "params are ", repo, auth, params
         pr = create_pull_request(repo; auth=auth, params=params)
         msg = "created"
         @debug("Pull request created")

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -26,7 +26,6 @@ function get_access_token(evt::WebhookEvent)
     get_access_token(evt.repository.owner.login, evt.repository.name)
 end
 function get_access_token(namespace::AbstractString, name::AbstractString)
-    @info "params = ", namespace, name
     get_token_for_repo(get_tokens_ctx(), namespace, name)
 end
 function get_access_token(repo::AbstractString)
@@ -35,6 +34,10 @@ function get_access_token(repo::AbstractString)
 end
 function get_access_token(repo::GitHub.Repo)
     get_access_token(repo.owner, repo.name)
+end
+
+function get_registry_token()
+    return CONFIG["github"]["token"]
 end
 
 function get_sha_from_branch(reponame, brn, auth)
@@ -69,7 +72,7 @@ function is_comment_by_org_owner_or_member(event)
     user = get_user_login(event.payload)
     user == "github-actions[bot]" && return true
     if get(CONFIG, "check_private_membership", false)
-        return GitHub.check_membership(org, user; auth=GitHub.authenticate(get_token_for_repo()))
+        return GitHub.check_membership(org, user; auth=GitHub.authenticate(get_access_token(event)))
     else
         return GitHub.check_membership(org, user; public_only=true)
     end
@@ -203,9 +206,8 @@ function create_or_find_pull_request(
 )
     pr = nothing
     msg = ""
-    auth = GitHub.authenticate(get_access_token(repo))
+    auth = GitHub.authenticate(get_registry_token())
     try
-        @info "params are ", repo, auth, params
         pr = create_pull_request(repo; auth=auth, params=params)
         msg = "created"
         @debug("Pull request created")

--- a/src/commentbot/github_utils.jl
+++ b/src/commentbot/github_utils.jl
@@ -1,3 +1,5 @@
+using GitHubAppTokens
+
 function register_rights_error(evt, user)
     if is_owned_by_organization(evt)
         org = evt.repository.owner.login
@@ -7,9 +9,30 @@ function register_rights_error(evt, user)
     end
 end
 
-get_access_token(event) = create_access_token(Installation(event.payload["installation"]), get_jwt_auth())
-get_user_auth() = GitHub.authenticate(CONFIG["github"]["token"])
-get_jwt_auth() = GitHub.JWTAuth(CONFIG["github"]["app_id"], CONFIG["github"]["priv_pem"])
+TOKENS_CTX = Ref{GHAppCtx}(nothing)
+function get_tokens_ctx()
+    if TOKENS_CTX[] === nothing
+        TOKENS_CTX[] = GHAppCtx(CONFIG["github"]["app_id"], CONFIG["github"]["priv_pem"])
+    end
+    TOKENS_CTX[]
+end
+
+function get_access_token(evt::WebhookEvent)
+    get_access_token(evt.repository.owner, evt.repository.name)
+end
+function get_access_token(namespace::AbstractString, name::AbstractString)
+    get_token_for_repo(get_tokens_ctx(), namespace, name)
+end
+function get_user_auth(namespace::AbstractString, name::AbstractString)
+    GitHub.authenticate(get_access_token(namespace, name))
+end
+function get_user_auth(repo::AbstractString)
+    namespace, name = split(repo, "/")
+    get_user_auth(namespace, name)
+end
+function get_user_auth(repo::GitHub.Repo)
+    get_user_auth(repo.owner, repo.name)
+end
 
 function get_sha_from_branch(reponame, brn; auth = GitHub.AnonymousAuth())
     try
@@ -43,7 +66,7 @@ function is_comment_by_org_owner_or_member(event)
     user = get_user_login(event.payload)
     user == "github-actions[bot]" && return true
     if get(CONFIG, "check_private_membership", false)
-        return GitHub.check_membership(org, user; auth=get_user_auth())
+        return GitHub.check_membership(org, user; auth=GitHub.authenticate(get_token_for_repo()))
     else
         return GitHub.check_membership(org, user; public_only=true)
     end
@@ -70,10 +93,10 @@ get_clone_url(event) = event.payload["repository"]["clone_url"]
 function make_comment(evt::WebhookEvent, body::AbstractString)
     CONFIG["reply_comment"] || return
     @debug("Posting comment to PR/issue")
-    headers = Dict("private_token" => CONFIG["github"]["token"])
+    headers = Dict("private_token" => get_access_token(evt))
     params = Dict("body" => body)
     repo = evt.repository
-    auth = get_user_auth()
+    auth = GitHub.authenticate(get_user_auth(repo))
     if is_commit_comment(evt.payload)
         GitHub.create_comment(repo, get_comment_commit_id(evt),
                               :commit; headers=headers,
@@ -177,7 +200,7 @@ function create_or_find_pull_request(
 )
     pr = nothing
     msg = ""
-    auth = get_user_auth()
+    auth = get_user_auth(repo)
     try
         pr = create_pull_request(repo; auth=auth, params=params)
         msg = "created"

--- a/src/commentbot/param_types.jl
+++ b/src/commentbot/param_types.jl
@@ -180,7 +180,7 @@ struct ProcessedParams
         err = nothing
         report_error = true
 
-        auth = GitHub.authenticate(get_access_token(rp.evt))
+        auth = get_app_auth(rp.evt)
         cloneurl, sha, err = get_cloneurl_and_sha(rp, auth)
 
         if err === nothing && sha !== nothing

--- a/src/commentbot/param_types.jl
+++ b/src/commentbot/param_types.jl
@@ -125,7 +125,7 @@ end
 
 function get_cloneurl_and_sha(rp::RequestParams{IssueTrigger}, auth)
     cloneurl = get_clone_url(rp.evt)
-    sha, err = get_sha_from_branch(rp.reponame, rp.trigger_src.branch; auth=auth)
+    sha, err = get_sha_from_branch(rp.reponame, rp.trigger_src.branch, auth)
 
     cloneurl, sha, err
 end
@@ -180,17 +180,11 @@ struct ProcessedParams
         err = nothing
         report_error = true
 
-        is_private = rp.evt.payload["repository"]["private"]
-        if is_private
-            auth = get_access_token(rp.evt)
-        else
-            auth = GitHub.AnonymousAuth()
-        end
-
+        auth = GitHub.authenticate(get_access_token(rp.evt))
         cloneurl, sha, err = get_cloneurl_and_sha(rp, auth)
 
         if err === nothing && sha !== nothing
-            project, tree_sha, projectfile_found, projectfile_valid, err = verify_projectfile_from_sha(rp.reponame, sha; auth = auth, subdir = rp.subdir)
+            project, tree_sha, projectfile_found, projectfile_valid, err = verify_projectfile_from_sha(rp.reponame, sha, auth; subdir = rp.subdir)
             if !projectfile_found
                 err = "File (Julia)Project.toml not found"
                 @debug(err)

--- a/src/commentbot/verify_projectfile.jl
+++ b/src/commentbot/verify_projectfile.jl
@@ -89,7 +89,7 @@ function pfile_hasfields(p::RegistryTools.Project)
     return true, nothing
 end
 
-function verify_projectfile_from_sha(reponame, commit_sha; auth=GitHub.AnonymousAuth(), subdir = "")
+function verify_projectfile_from_sha(reponame, commit_sha, auth; subdir = "")
     project = nothing
     projectfile_found = false
     projectfile_valid = false
@@ -110,12 +110,7 @@ function verify_projectfile_from_sha(reponame, commit_sha; auth=GitHub.Anonymous
             @debug("(Julia)Project file found")
 
             @debug("Getting projectfile blob")
-            if isa(auth, GitHub.AnonymousAuth)
-                a = get_user_auth()
-            else
-                a = auth
-            end
-            b = blob(reponame, Blob(tr["sha"]); auth=a)
+            b = blob(reponame, Blob(tr["sha"]); auth=auth)
 
             @debug("Decoding base64 projectfile contents")
             projectfile_contents = decodeb64(b.content)

--- a/src/webui/WebUI.jl
+++ b/src/webui/WebUI.jl
@@ -256,7 +256,7 @@ end
 function main(config::AbstractString=isempty(ARGS) ? "config.toml" : first(ARGS))
     merge!(CONFIG, TOML.parsefile(config)["web"])
     if get(CONFIG, "enable_logging", true)
-        global_logger(SimpleLogger(stdout, get_log_level(get(CONFIG, "log_level", "INFO"))))
+        global_logger(ConsoleLogger(stdout, get_log_level(get(CONFIG, "log_level", "INFO"))))
     end
     zsock = RequestSocket(get(CONFIG, "backend_port", 5555))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using GitForge: GitForge, GitHub, GitLab, Bitbucket
 using GitForge.GitHub: GitHub, GitHubAPI, NoToken, Token
 
 using Registrator: Registrator
-using Registrator.CommentBot: make_trigger, parse_comment
+using Registrator.CommentBot: make_trigger, parse_comment, reponame_from_url
 using Registrator.WebUI: @gf
 using Registrator.WebUI: isauthorized, AuthFailure, AuthSuccess, User
 

--- a/test/server.jl
+++ b/test/server.jl
@@ -43,3 +43,8 @@ end
     @test ok == true
     @test err === nothing
 end
+
+@testset "reponame_from_url" begin
+    @test reponame_from_url("https://github.com/JuliaLang/julia") == "JuliaLang/julia"
+    @test reponame_from_url("git@github.com:JuliaLang/julia") == "JuliaLang/julia"
+end


### PR DESCRIPTION
Towards https://github.com/JuliaRegistries/Registrator.jl/issues/470

Uses [GitHubAppTokens.jl](https://github.com/JuliaComputing/GitHubAppTokens.jl) to generate tokens for package repo operations. (Registry operations will still use the existing static token, see [comment](https://github.com/JuliaRegistries/Registrator.jl/issues/470#issuecomment-4075605560)).

Summary of changes:
- `get_access_token` now uses `GitHubAppTokens.get_token_for_repo` to generate token. GitHubAppTokens caches and manages expiry/refresh of tokens.
- Replace `get_user_auth` with `get_app_auth` and `get_registry_auth`.
  - `get_registry_auth` is the same as the old `get_user_auth`. This is what we will to use for registry operations for now.
  - `get_app_auth` wraps `get_access_token` with `GitHub.authenticate!`. We use this for package repo operations.
- Adds new dependency [GitHubAppTokens.jl](https://github.com/JuliaComputing/GitHubAppTokens.jl) to Project.toml, bumped minor version.
- Calls `ConsoleLogger` now instead of `SimpleLogger` when initializing logger. Prints better stacktraces.
- Moves `reponame_from_url` to gitutils.jl
- Changes optional `auth` kwarg for some helper methods to required `auth` arg since we always want to use authentication when making GitHub API calls.