### PR TITLE
🤖 fix(commentbot): comment when Project.toml fails to parse

### DIFF
--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -171,17 +171,7 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
         end
     end
 
-    local pp
-    try
-        pp = ProcessedParams(rp)
-    catch ex
-        @info "Unexpected error while preprocessing registration" exception = (ex, catch_backtrace())
-        msg = "Error while trying to register: preprocessing failed — $(sprint(showerror, ex))"
-        make_comment(rp.evt, msg)
-        set_error_status(rp)
-        @info("Done processing register event", reponame=rp.reponame, target_registry_name)
-        return nothing
-    end
+    pp = ProcessedParams(rp)
     @info("Processing register event", reponame=rp.reponame, target_registry_name)
     try
         if pp.cparams.isvalid

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -202,9 +202,9 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
                 set_success_status(rp)
             end
         else
-            @info("Error while processing event: $(repr(pp.cparams.error))")
+            @info("Error while processing event: $(pp.cparams.error)")
             if pp.cparams.report_error
-                msg = "Error while trying to register: $(repr(pp.cparams.error))"
+                msg = "Error while trying to register: $(pp.cparams.error)"
                 @debug(msg)
                 make_comment(rp.evt, msg)
             end

--- a/src/commentbot/CommentBot.jl
+++ b/src/commentbot/CommentBot.jl
@@ -171,7 +171,17 @@ function action(rp::RequestParams{T}, zsock::RequestSocket) where T <: RegisterT
         end
     end
 
-    pp = ProcessedParams(rp)
+    local pp
+    try
+        pp = ProcessedParams(rp)
+    catch ex
+        @info "Unexpected error while preprocessing registration" exception = (ex, catch_backtrace())
+        msg = "Error while trying to register: preprocessing failed — $(sprint(showerror, ex))"
+        make_comment(rp.evt, msg)
+        set_error_status(rp)
+        @info("Done processing register event", reponame=rp.reponame, target_registry_name)
+        return nothing
+    end
     @info("Processing register event", reponame=rp.reponame, target_registry_name)
     try
         if pp.cparams.isvalid

--- a/src/commentbot/verify_projectfile.jl
+++ b/src/commentbot/verify_projectfile.jl
@@ -1,6 +1,22 @@
 using ..Registrator: decodeb64
 import RegistryTools
 
+function _markdown_fenced_code(content::AbstractString)
+    max_run = 0
+    run = 0
+    for c in content
+        if c == '`'
+            run += 1
+            max_run = max(max_run, run)
+        else
+            run = 0
+        end
+    end
+    n = max(3, max_run + 1)
+    fence = repeat('`', n)
+    return fence * "\n" * content * "\n" * fence
+end
+
 function _unwrap_toml_parser_error(ex)
     if isa(ex, TOML.ParserError)
         return ex
@@ -24,7 +40,7 @@ function _format_toml_parse_error(ex)
         return nothing
     end
     desc = sprint(showerror, pex)
-    return "Could not parse (Julia)Project.toml as TOML: " * desc
+    return "Could not parse (Julia)Project.toml as TOML:\n\n" * _markdown_fenced_code(desc)
 end
 
 function is_pfile_parseable(c::AbstractString)
@@ -39,7 +55,7 @@ function is_pfile_parseable(c::AbstractString)
                 @debug(msg)
                 return false, msg
             end
-            rethrow(ex)
+            rethrow()
         end
     else
         err = "Project file is empty"
@@ -111,7 +127,8 @@ function verify_projectfile_from_sha(reponame, commit_sha; auth=GitHub.Anonymous
                 try
                     project = RegistryTools.Project(TOML.parse(projectfile_contents))
                 catch ex
-                    err = "Failed to read project file: " * sprint(showerror, ex)
+                    detail = sprint(showerror, ex)
+                    err = "Failed to read project file:\n\n" * _markdown_fenced_code(detail)
                     @error(err)
                 end
                 if project !== nothing

--- a/src/commentbot/verify_projectfile.jl
+++ b/src/commentbot/verify_projectfile.jl
@@ -1,6 +1,32 @@
 using ..Registrator: decodeb64
 import RegistryTools
 
+function _unwrap_toml_parser_error(ex)
+    if isa(ex, TOML.ParserError)
+        return ex
+    end
+    if isa(ex, CompositeException)
+        for e in ex.exceptions
+            if isa(e, TOML.ParserError)
+                return e
+            end
+            if isa(e, Base.CapturedException) && isa(e.ex, TOML.ParserError)
+                return e.ex
+            end
+        end
+    end
+    return nothing
+end
+
+function _format_toml_parse_error(ex)
+    pex = _unwrap_toml_parser_error(ex)
+    if pex === nothing
+        return nothing
+    end
+    desc = sprint(showerror, pex)
+    return "Could not parse (Julia)Project.toml as TOML: " * desc
+end
+
 function is_pfile_parseable(c::AbstractString)
     @debug("Checking whether (Julia)Project.toml is non-empty and parseable")
     if length(c) != 0
@@ -8,13 +34,12 @@ function is_pfile_parseable(c::AbstractString)
             TOML.parse(c)
             return true, nothing
         catch ex
-            if isa(ex, CompositeException) && isa(ex.exceptions[1], TOML.ParserError)
-                err = "Error parsing project file"
-                @debug(err)
-                return false, err
-            else
-                rethrow(ex)
+            msg = _format_toml_parse_error(ex)
+            if msg !== nothing
+                @debug(msg)
+                return false, msg
             end
+            rethrow(ex)
         end
     else
         err = "Project file is empty"
@@ -86,10 +111,7 @@ function verify_projectfile_from_sha(reponame, commit_sha; auth=GitHub.Anonymous
                 try
                     project = RegistryTools.Project(TOML.parse(projectfile_contents))
                 catch ex
-                    err = "Failed to read project file"
-                    if isdefined(ex, :msg)
-                        err = err * ": $(e.msg)"
-                    end
+                    err = "Failed to read project file: " * sprint(showerror, ex)
                     @error(err)
                 end
                 if project !== nothing

--- a/test/server.jl
+++ b/test/server.jl
@@ -25,3 +25,21 @@ end
 
     @test parse_comment("register branch=foo branch=bar") == (nothing, nothing)
 end
+
+@testset "is_pfile_parseable" begin
+    ok, err = Registrator.CommentBot.is_pfile_parseable("")
+    @test ok == false
+    @test err == "Project file is empty"
+
+    ok, err = Registrator.CommentBot.is_pfile_parseable("a = [")
+    @test ok == false
+    @test occursin("Could not parse (Julia)Project.toml as TOML:", err)
+
+    ok, err = Registrator.CommentBot.is_pfile_parseable("""
+    name = "Foo"
+    uuid = "54e30f9d-21f3-4213-8955-9a4b7cb3eed7"
+    version = "0.1.0"
+    """)
+    @test ok == true
+    @test err === nothing
+end


### PR DESCRIPTION
- Handle TOML.ParserError and CompositeException/CapturedException
- Include parser showerror text in the GitHub reply message
- Fix RegistryTools.Project error reporting (use showerror, not broken e.msg)
- Wrap ProcessedParams in action() so preprocessing errors still notify users
- Add is_pfile_parseable unit tests

Made-with: Cursor

This hopefully fixes #483.
Most tests pass locally, but i have not tested if the problem from #483 is actually fixed. 
🤖 Code written by Cursor, but looks reasonable to me.