### PR TITLE
CI: replace unmaintained Julia 1.7 jobs with 'lts'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          # Julia maintains only two release lines: the current stable release
+          # and the current long-term support (LTS) release. Everything else is
+          # unmaintained.
+          - 'lts'
           - '1'
           - 'nightly'
         os:
           - ubuntu-latest
-        include:
-          - version: '1.7.2'
-            os: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -37,15 +37,10 @@ jobs:
       - name: Run the package tests
         run: |
           import Pkg
-          force_use_of_manifest = false
-          allow_reresolve = !force_use_of_manifest
+          allow_reresolve = true
           coverage = true
-          if allow_reresolve && VERSION >= v"1.9"
-            force_latest_compatible_version = true
-            Pkg.test(; allow_reresolve, coverage, force_latest_compatible_version)
-          else
-            Pkg.test(; allow_reresolve, coverage)
-          end
+          force_latest_compatible_version = true
+          Pkg.test(; allow_reresolve, coverage, force_latest_compatible_version)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: julia --color=yes --project {0}

--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ TimeToLive = "0.2, 0.3"
 URIs = "1.6" # Must be >= 1.6, see https://github.com/JuliaRegistries/Registrator.jl/pull/453
 UUIDs = "1"
 ZMQ = "1"
-julia = "1.1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/util.jl
+++ b/test/util.jl
@@ -9,9 +9,7 @@ function start_server(
             UI.start_server(Sockets.localhost, port)
         end
     end
-    if Base.VERSION >= v"1.7-"
-        errormonitor(server_task)
-    end
+    errormonitor(server_task)
     @info "Starting the server..."
     sleep(10)
     return server_task


### PR DESCRIPTION
CI currently tests on Julia `1.7`, `1`, `nightly`, plus a pinned `1.7.2` job. This replaces the 1.7 jobs with `lts`.

### Why 1.7 should go

- **It has been unmaintained for four years.** Julia maintains exactly two release lines: current stable (1.12) and current LTS (1.10). Julia 1.7.0 was released 2021-11-30, its final patch 1.7.3 on 2022-05-25, and it went unmaintained on 2022-08-17 when 1.8.0 shipped. There is no 1.7.4.

- **The pinned `1.7.2` job no longer has a reason to exist.** It was added in #388 so that one job would match the `julia_version` recorded in the checked-in `Manifest.toml`. That manifest was deleted in #458 (after it was confirmed in #456 that it is not used in deployments), so the job now only shadows the `'1.7'` job.

- **The old jobs were already being tested more weakly than the rest.** `force_use_of_manifest` has been a hardcoded `false` since #458, and #473 added a `VERSION >= v"1.9"` guard so that `force_latest_compatible_version` would not run on 1.7/1.8. With the old jobs removed, both branches collapse into a single unconditional `Pkg.test` call.

- **1.7 was silently giving no coverage of the newest code.** `HTTP` v2 declares `julia = "1.10"` in the General registry, so the HTTP2 support added in #488 could never be installed on the 1.7 jobs — they resolved `HTTP` v1 no matter what. Same for `GitForge` 0.4.5.

### Second commit (separable)

`[compat] julia = "1.1"` has never been checked by CI and is not accurate: `GitHub` 5.11+, `RegistryTools` 2.4+, `GitForge` 0.4.3+ and `URIs` 1.4+ all require Julia ≥ 1.6, and `HTTP` v2 requires ≥ 1.10. The second commit sets it to `1.10` so the declared bound matches the oldest version CI runs, and drops the now-dead `Base.VERSION >= v"1.7-"` guard in `test/util.jl`.

**I have deliberately kept this as its own commit.** I could not find any public record of which Julia version the deployed `@JuliaRegistrator` instance runs on — `Dockerfile` says `FROM julia:latest`, but that is the self-hosting reference image, not the deployment. If production is on something older than 1.10, please drop the second commit and take only the CI change; the two are independent.

Happy to adjust either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
