### PR TITLE
Fix `withpasswd` userinfo handling for URIs.jl v1.7

### DIFF
--- a/src/webui/gitutils.jl
+++ b/src/webui/gitutils.jl
@@ -281,7 +281,12 @@ function withpasswd(func, url::URI)
     local info = url.userinfo
     isempty(info) &&
         return func(url, [])
-    local user, passwd = split(info, ":")
+    # RFC 3986 3.2.1 allows only unreserved characters, sub-delims and ":" to
+    # appear literally in userinfo; anything else (e.g. `"` or `>`) must be
+    # percent-encoded, and URIs.jl v1.7 rejects URLs where it is not. Split
+    # before unescaping so that a percent-encoded ":" stays part of the
+    # password, and limit the split so that a literal ":" does too.
+    local user, passwd = unescapeuri.(split(info, ":"; limit=2))
     local newurl = URI(replace(string(url), "$info@" => ""))
     mktemp() do path, io
         # base64 encode now and decode while printing out in shell to avoid shell injection

--- a/test/webui/gitutils.jl
+++ b/test/webui/gitutils.jl
@@ -70,7 +70,9 @@ end
     @test isauthorized("username", "reponame") == AuthFailure("Unkown user type or repo type")
     mock_provider!()
 
-    Registrator.WebUI.withpasswd("https://foo:bar\">&baz@github.com/owner/repo") do newurl,envs
+    # `"` and `>` are not legal literals in userinfo, so they arrive
+    # percent-encoded; the password below decodes to `bar">&baz`.
+    Registrator.WebUI.withpasswd("https://foo:bar%22%3E%26baz@github.com/owner/repo") do newurl,envs
         askpass=envs[1]
         script=split(askpass, '=')[2]
     


### PR DESCRIPTION
CI on `master` is currently red. AI tells me that the reason is that URIs.jl v1.7.0 was recently released and tightened URI validation ("Reject invalid authorities, malformed percent escapes, non-decimal ports, and raw ASCII controls"). The last CI run on `master` was before that release, so the breakage has not been observed yet.

### The failure

`test/webui/gitutils.jl` builds

```
https://foo:bar">&baz@github.com/owner/repo
```

and hands it to `withpasswd`, which calls `URI(url)`. Under URIs v1.7.0 that throws:

```
URIs.ParseError("Invalid URI userinfo: foo:bar\">&baz")
```

which surfaces as an error in the `isauthorized` testset. URIs v1.6.3 accepted it.

RFC 3986 §3.2.1 allows only unreserved characters, sub-delims and `:` to appear literally in userinfo. `&` is a sub-delim and is fine; `"` and `>` are neither, and must be percent-encoded. The test is constructing an invalid URI and this is now detected.

### The fix (suggested by AI)

Percent-encode the password in the test (`bar%22%3E%26baz`), the way a real client would send it, and `unescapeuri` it in `withpasswd` so that what reaches Git is the password rather than its encoded form. The test's original intent — that shell metacharacters in a password cannot escape the generated `GIT_ASKPASS` script — is preserved, since the decoded value is still `bar">&baz`.

This also fixes a latent bug: before this change, a clone URL containing `bar%22%3E%26baz` (which is valid) would have written the literal percent escapes into the askpass script, so Git would have been given the wrong password.

### Also in this commit

`split(info, ":")` on a userinfo whose password contains a literal `:` returns three parts, and the destructuring assignment silently dropped the tail — `foo:ba:r` produced the password `ba`. Added `limit=2`.

### Verification

Verified against both URIs v1.6.3 and v1.7.0, covering the encoded password, a literal `:` in the password, a percent-encoded `:`, and the no-userinfo path.


Note: #490 (replacing the unmaintained Julia 1.7 CI jobs with `lts`) is failing on this error. I expect its CI to pass once this is merged.
